### PR TITLE
Change for #22896 - Added hook_filter_publishes

### DIFF
--- a/hooks/filter_publishes.py
+++ b/hooks/filter_publishes.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+import sgtk
+from sgtk import Hook
+
+class FilterPublishes(Hook):
+    """
+    Hook that can be used to filter the list of publishes returned from Shotgun for the current
+    location
+    """
+    
+    def execute(self, publishes, **kwargs):
+        """
+        Main hook entry point
+        
+        :param publishes:    List of dictionaries 
+                             A list of  dictionaries for the current location within the app.  Each
+                             item in the list is a Dictionary of the form:
+                             
+                             {
+                                 "sg_publish" : {Shotgun entity dictionary for a Published File entity}
+                             }
+                             
+                                                         
+        :return List:        The filtered list of dictionaries of the same form as the input 'publishes' 
+                             list
+        """
+        app = self.parent
+
+        # the default implementation just returns the unfiltered list:
+        return publishes

--- a/info.yml
+++ b/info.yml
@@ -36,6 +36,12 @@ configuration:
         default_value: "load_action_{engine_name}"
         description: The list hook carries out the actual loading of a given load action.
 
+    hook_filter_publishes:
+        type: hook
+        parameters: [publishes]
+        default_value: filter_publishes
+        description: Specify a hook that, if needed, can filter the raw list of publishes returned
+                     from Shotgun for the current location.
 
     entities:
         default_value: 

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -299,11 +299,36 @@ class SgLatestPublishModel(ShotgunModel):
         :param sg_data_list: list of shotgun dictionaries, as retunrned by the find() call.
         :returns: should return a list of shotgun dictionaries, on the same form as the input.
         """
+        app = sgtk.platform.current_bundle()
 
+        try:
+            # first, let the hook_filter_publishes have a chance to filter
+            # the list of publishes:
+            
+            # Constructing a wrapper dictionary so that it's future proof to support returning
+            # additional information from the hook 
+            hook_publish_list = [{"sg_publish":sg_data} for sg_data in sg_data_list] 
+            
+            hook_publish_list = app.execute_hook("hook_filter_publishes", publishes=hook_publish_list)
+            if not isinstance(hook_publish_list, list):
+                app.log_error("hook_filter_publishes returned an unexpected result type '%s' - ignoring!" 
+                              % type(sg_data_list).__name__)
+                hook_publish_list = []
+
+            # split back out publishes:
+            sg_data_list = []
+            for item in hook_publish_list:
+                sg_data = item.get("sg_publish")
+                if sg_data:
+                    sg_data_list.append(sg_data)
+            
+        except:
+            app.log_exception("Failed to execute 'hook_filter_publishes'!")
+            sg_data_list = []
+        
         # filter the shotgun data so that we only return the latest publish for each file.
         # also perform aggregate computations and push those summaries into the associated
         # publish type model. 
-
         
         if len(sg_data_list) == 0 and len(self._treeview_folder_items) == 0:
             # no publishes or folders found!


### PR DESCRIPTION
Added a new hook (hook_filter_publishes) to be able to filter the list of publishes returned from Shotgun to those currently mapped by the users Perforce workspace - the default implementation does nothing
