### PR TITLE
for #25235 fix 3dsmax import action and add simple reference action

### DIFF
--- a/hooks/tk-3dsmax_actions.py
+++ b/hooks/tk-3dsmax_actions.py
@@ -65,12 +65,18 @@ class MaxActions(HookBaseClass):
         action_instances = []
         
 
-        if "import" in actions:        
+        if "import" in actions:
             action_instances.append( {"name": "merge",
                                       "params": None, 
-                                      "caption": "Merge Contents", 
-                                      "description": "This will merge the contents into the current scene."} )        
-    
+                                      "caption": "Merge", 
+                                      "description": "This will merge the contents of this file into the current scene."} )        
+        
+        if "reference" in actions:
+            action_instances.append( {"name": "xref_scene",
+                                      "params": None, 
+                                      "caption": "XRef Scene", 
+                                      "description": "This will insert a reference to this file into the current scene."} )        
+        
         return action_instances
                 
 
@@ -93,6 +99,8 @@ class MaxActions(HookBaseClass):
         
         if name == "merge":
             self._merge(path, sg_publish_data)
+        elif name == "xref_scene":
+            self._xref_scene(path, sg_publish_data)
         
     
     ##############################################################################################################
@@ -112,9 +120,31 @@ class MaxActions(HookBaseClass):
         
         (_, ext) = os.path.splitext(path)
         
-        if ext.lower() != ".max":
-            raise Exception("Unsupported file extension for '%s'. Only .max files are supported." % path)
+        supported_file_exts = [".max"]
+        if ext.lower() not in supported_file_exts:
+            raise Exception("Unsupported file extension for '%s'. "
+                            "Supported file extensions are: %s" % (path, supported_file_exts))
         
         mxs.mergeMAXFile(path)
 
 
+    def _xref_scene(self, path, sg_publish_data):
+        """
+        Insert a reference to the given external file into the current scene.
+        
+        :param path: Path to file.
+        :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
+        """
+        from Py3dsMax import mxs
+        
+        if not os.path.exists(path):
+            raise Exception("File not found on disk - '%s'" % path)
+        
+        (_, ext) = os.path.splitext(path)
+        
+        supported_file_exts = [".max"]
+        if ext.lower() not in supported_file_exts:
+            raise Exception("Unsupported file extension for '%s'. "
+                            "Supported file extensions are: %s" % (path, supported_file_exts))
+        
+        mxs.xrefs.addNewXRefFile(path)

--- a/info.yml
+++ b/info.yml
@@ -53,7 +53,7 @@ configuration:
         default_value_tk-motionbuilder: 
             Motion Builder FBX: [import]
         default_value_tk-3dsmax:
-            3dsmax Scene: [import]
+            3dsmax Scene: [import, reference]
         default_value_tk-photoshop:
             Photoshop Image: [open_file]
 


### PR DESCRIPTION
3dsmax terminology for importing the contents of a scene file into the current scene is "merge". Updated the actions to reflect that while maintaining the consistent "import" terminology on the tk side. 

Also added a simple "reference" action for referencing the contents of a selected scene file and matched the 3dsmax terminology ("xref"). 
