### PR TITLE
25877 Fixed issue which obscures certain publishes in the main overview

### DIFF
--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -137,6 +137,24 @@ class SgPublishDelegate(shotgun_view.WidgetDelegate):
             if sg_data.get("version_number"):
                 name_str += " v%s" % sg_data.get("version_number")
 
+            # now we are tracking whether this item has a unique task/name/type combo
+            # or not via the specially injected task_uniqueness boolean.
+            # If this is true, that means that this is the only item in the listing
+            # with this name/type combo, and we can render its display name on two 
+            # lines, name first and then type, e.g.:
+            # MyScene, v3
+            # Maya Render
+            #
+            # However, there can be multiple *different* tasks which have the same 
+            # name/type combo - in this case, we want to display the task name too
+            # since this is what differentiates the data. In that case we display it:
+            # MyScene, v3 (Layout)
+            # Maya Render
+            #
+            if sg_data.get("task_uniqueness") == False and sg_data.get("task") is not None:
+                name_str += " (%s)" % sg_data["task"]["name"]
+
+
             if self._show_entity_instead_of_type:
 
                 # display this publish in sub items node


### PR DESCRIPTION
Fixes a bug which would cause publishes to now show up in the main overview if there were two publish "streams" with the same name and type but with different tasks. These would be shown as single entry rather than two independent streams. This change generates two distinct streams and also attaches the task name next to the publish name in the display so that the two different streams are distinguishable from each other.
