### PR TITLE
Loader now adds a layer instead of opening a file in Photoshop

### DIFF
--- a/hooks/tk-photoshop_actions.py
+++ b/hooks/tk-photoshop_actions.py
@@ -15,10 +15,14 @@ import sgtk
 import os
 from sgtk.platform.qt import QtGui
 
+from photoshop import RemoteObject, app as ph_app # Deambiguate code referencing toolkit app and Photoshop app.
+from photoshop.flexbase import requestStatic
+
 HookBaseClass = sgtk.get_hook_baseclass()
 
 # Name of available actions. Corresponds to both the environment config values and the action instance names.
-_ADD_TO_LAYER = "add_to_layer"
+_ADD_AS_A_LAYER = "add_as_a_layer"
+_OPEN_FILE = "open_file"
 
 
 class PhotoshopActions(HookBaseClass):
@@ -69,12 +73,18 @@ class PhotoshopActions(HookBaseClass):
         
         action_instances = []
         
-        if _ADD_TO_LAYER in actions:
-            action_instances.append({"name": _ADD_TO_LAYER,
+        if _ADD_AS_A_LAYER in actions:
+            action_instances.append({"name": _ADD_AS_A_LAYER,
                                      "params": None,
-                                     "caption": "Add To Layer",
+                                     "caption": "Add as a Layer",
                                      "description": "Adds a layer referencing the image to the current document."})
-    
+
+        if _OPEN_FILE in actions:
+            action_instances.append({"name": _OPEN_FILE,
+                                     "params": None,
+                                     "caption": "Open File",
+                                     "description": "This will open the file."})
+
         return action_instances
                 
 
@@ -92,18 +102,30 @@ class PhotoshopActions(HookBaseClass):
         app.log_debug("Execute action called for action %s. "
                       "Parameters: %s. Publish Data: %s" % (name, params, sg_publish_data))
 
-        import photoshop
-        if not photoshop.app.activeDocument:
-            QtGui.QMessageBox.warning(None, "Add To Layer", ("Please open a document first."))
-            return
         # resolve path
         path = self.get_publish_path(sg_publish_data)
-        
-        if name == _ADD_TO_LAYER:
+
+        if not os.path.exists(path):
+            raise Exception("File not found on disk - '%s'" % path)
+
+        if name == _OPEN_FILE:
+            self._open_file(path, sg_publish_data)
+        if name == _ADD_AS_A_LAYER:
             self._place_file(path, sg_publish_data)
 
     ##############################################################################################################
     # helper methods which can be subclassed in custom hooks to fine tune the behavior of things
+
+    def _open_file(self, path, sg_publish_data):
+        """
+        Import contents of the given file into the scene.
+        
+
+        :param path: Path to file.
+        :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
+        """
+        f = RemoteObject('flash.filesystem::File', path)
+        ph_app.load(f)  
 
     def _place_file(self, path, sg_publish_data):
         """
@@ -112,11 +134,11 @@ class PhotoshopActions(HookBaseClass):
         :param path: Path to file.
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         """
-        if not os.path.exists(path):
-            raise Exception("File not found on disk - '%s'" % path)
 
-        from photoshop import RemoteObject, app
-        from photoshop.flexbase import requestStatic
+        # We can't import in an empty scene.
+        if not ph_app.activeDocument:
+            QtGui.QMessageBox.warning(None, "Add To Layer", "Please open a document first.")
+            return
 
         # When File->Place'ing a PSD on top of another, here's what the Script Listener generates.
         # (Download at http://helpx.adobe.com/photoshop/kb/plug-ins-photoshop-cs61.html#id_68969)
@@ -133,19 +155,25 @@ class PhotoshopActions(HookBaseClass):
         # executeAction( idPlc, placeActionDesc, DialogModes.NO );
 
         # Get some shortcuts to functions we need to use often.
-        charIDToTypeID = app.charIDToTypeID
-        executeAction = app.executeAction
+        stringIDToTypeID = ph_app.stringIDToTypeID
+
+        # For clarity sake, we'll use string IDs instead of charIDs. You can find the Photoshop Rosetta Stone here:
+        # http://www.pcpix.com/photoshop/enum.htm
 
         # Create an action descriptor that will be used to identify which PSD to place in the current one.
         placeActionDesc = RemoteObject("com.adobe.photoshop::ActionDescriptor")
-        placeActionDesc.putPath(charIDToTypeID("null"), RemoteObject("flash.filesystem::File", path))
+        placeActionDesc.putPath(stringIDToTypeID("null"), RemoteObject("flash.filesystem::File", path))
 
         # FIXME: Not sure why these are set, but they are mandatory and seem to be transform related. Omitting them
-        # makes the Place action fail... This is the best I could find as far as documentation goes:
-        # http://www.pcpix.com/photoshop/string.htm . These flags seem to be poorly documented and all over code samples
-        # found on the web using the Place action uses them without any mention as to what they mean.
-        placeActionDesc.putEnumerated(charIDToTypeID("FTcs"), charIDToTypeID("QCSt"), charIDToTypeID("Qcsa"))
+        # makes the Place action fail, even if we don't specify a transform. These flags seem to be poorly documented
+        # and code samples found on the web using the Place action uses them without any mention as to what they
+        # mean.
+        placeActionDesc.putEnumerated(
+            stringIDToTypeID("freeTransformCenterState"), stringIDToTypeID("quadCenterState"),
+            stringIDToTypeID("QCSAverage")
+        )
 
-        # Runs the action. The extra space after Plc is required and is part of the name of the action. Omitting it
-        # fails.
-        executeAction(charIDToTypeID("Plc "), placeActionDesc, requestStatic("com.adobe.photoshop.DialogModes", "NO"))
+        # Everything is setup. Adds the layer to the document.
+        ph_app.executeAction(
+            stringIDToTypeID("placeEvent"), placeActionDesc, requestStatic("com.adobe.photoshop.DialogModes", "NO")
+        )

--- a/info.yml
+++ b/info.yml
@@ -68,8 +68,8 @@ configuration:
         default_value_tk-motionbuilder:
             Motion Builder FBX: [import]
         default_value_tk-photoshop:
-            Photoshop Image: [add_to_layer]
-            Rendered Image: [add_to_layer]
+            Photoshop Image: [add_as_a_layer, open_file]
+            Rendered Image: [add_as_a_layer, open_file]
         default_value_tk-mari:
             Alembic Cache: [geometry_import]
 


### PR DESCRIPTION
This branch implements the Add To Layer action for the loader. It supports both images and PSDs.
The 3 main tasks were:
- Renaming the Open File action to Add To Layer.
- Adding a check to make sure there is a current document.
- Using the Place action to create the layer.
