### PR TITLE
#30132 Implements the new asynchronous thumb loading.

### DIFF
--- a/python/tk_multi_loader/model_entity.py
+++ b/python/tk_multi_loader/model_entity.py
@@ -47,7 +47,7 @@ class SgEntityModel(ShotgunOverlayModel):
                                      overlay_widget, 
                                      download_thumbs=False, 
                                      schema_generation=4,
-                                     bg_thumbs=True)
+                                     bg_load_thumbs=True)
         fields=["image", "sg_status_list", "description"]
         self._load_data(entity_type, filters, hierarchy, fields)
     

--- a/python/tk_multi_loader/model_entity.py
+++ b/python/tk_multi_loader/model_entity.py
@@ -46,7 +46,8 @@ class SgEntityModel(ShotgunOverlayModel):
                                      parent, 
                                      overlay_widget, 
                                      download_thumbs=False, 
-                                     schema_generation=4)
+                                     schema_generation=4,
+                                     bg_thumbs=True)
         fields=["image", "sg_status_list", "description"]
         self._load_data(entity_type, filters, hierarchy, fields)
     

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -53,7 +53,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
                                      schema_generation=6,
-                                     bg_thumbs=True)
+                                     bg_load_thumbs=True)
 
     ############################################################################################
     # public interface

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -52,7 +52,8 @@ class SgLatestPublishModel(ShotgunOverlayModel):
                                      parent,
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
-                                     schema_generation=6)
+                                     schema_generation=6,
+                                     bg_thumbs=True)
 
     ############################################################################################
     # public interface
@@ -384,7 +385,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
         # set up publishes with a "thumbnail loading" icon
         item.setIcon(self._loading_icon)
 
-    def _populate_thumbnail(self, item, field, path):
+    def _populate_thumbnail_image(self, item, field, image, path):
         """
         Called whenever a thumbnail for an item has arrived on disk. In the case of
         an already cached thumbnail, this may be called very soon after data has been

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -37,7 +37,7 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
                                      schema_generation=2,
-                                     bg_thumbs=True)
+                                     bg_load_thumbs=True)
 
 
     ############################################################################################

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -36,7 +36,8 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
                                      parent,
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
-                                     schema_generation=2)
+                                     schema_generation=2,
+                                     bg_thumbs=True)
 
 
     ############################################################################################
@@ -161,7 +162,7 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
                                                               None)
         item.setIcon(QtGui.QIcon(thumb))
 
-    def _populate_thumbnail(self, item, field, path):
+    def _populate_thumbnail_image(self, item, field, image, path):
         """
         Called whenever a thumbnail for an item has arrived on disk. In the case of
         an already cached thumbnail, this may be called very soon after data has been

--- a/python/tk_multi_loader/model_publishtype.py
+++ b/python/tk_multi_loader/model_publishtype.py
@@ -40,7 +40,8 @@ class SgPublishTypeModel(ShotgunOverlayModel):
                                      parent, 
                                      overlay_widget, 
                                      download_thumbs=False,
-                                     schema_generation=2)
+                                     schema_generation=2,
+                                     bg_thumbs=True)
         
         self._action_manager = action_manager
         self._settings_manager = settings_manager

--- a/python/tk_multi_loader/model_publishtype.py
+++ b/python/tk_multi_loader/model_publishtype.py
@@ -41,7 +41,7 @@ class SgPublishTypeModel(ShotgunOverlayModel):
                                      overlay_widget, 
                                      download_thumbs=False,
                                      schema_generation=2,
-                                     bg_thumbs=True)
+                                     bg_load_thumbs=True)
         
         self._action_manager = action_manager
         self._settings_manager = settings_manager


### PR DESCRIPTION
This implements the new interface introduced in https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/15. This should improve performance, especially when I/O bandwidth isn't optimal.

Here's a comparative test on a slow cache storage - showing the new and the old cache running side by side: https://s3.amazonaws.com/uploads.hipchat.com/21107/193181/u7AisV1yqUxMuxx/ScreenFlow.mov

