### PR TITLE
Ticket #30252 - Show task info in the lists delegate.

### DIFF
--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -351,8 +351,12 @@ class SgPublishListDelegate(shotgun_view.WidgetDelegate):
 
             if sg_data.get("task") is not None:
                 main_text += ", Task %s" % sg_data["task"]["name"]
-                
+               
             main_text += ")"
+        elif sg_data.get("task") is not None:
+            # When not in subfolders mode always show Task info
+            # (similar to the logic in the thumbnail view, but always show)
+            main_text += "  (Task %s)" % sg_data["task"]["name"]
 
         # Quicktime by John Smith at 2014-02-23 10:34
         pub_type_str = shotgun_model.get_sanitized_data(model_index, SgLatestPublishModel.PUBLISH_TYPE_NAME_ROLE)            


### PR DESCRIPTION
Show the task info on the list view in the loader:

<img width="302" alt="shotgun__loader" src="https://cloud.githubusercontent.com/assets/319506/8712087/dea44d70-2b0c-11e5-8e55-db61169a61ed.png">

Always show it since we have the space and the logic about when it is shown or not in the Thumbnail view can be a little subtle and non-obvious.