### PR TITLE
Add status field to preloaded fields

### DIFF
--- a/python/tk_multi_loader/constants.py
+++ b/python/tk_multi_loader/constants.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Constants used by the loader.
+
+"""
+
+# fields to pull down for published files
+PUBLISHED_FILES_FIELDS = ["name",
+                          "version_number",
+                          "image",
+                          "entity",
+                          "path",
+                          "description",
+                          "sg_status_list",
+                          "task",
+                          "task.Task.sg_status_list",
+                          "task.Task.due_date",
+                          "project",
+                          "task.Task.content",
+                          "created_by",
+                          "created_at",
+                          "version", # note: not supported on TankPublishedFile so always None
+                          "version.Version.sg_status_list",
+                          "created_by.HumanUser.image"
+                          ]

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from sgtk.platform.qt import QtCore, QtGui
 
 import sgtk
-from . import utils
+from . import utils, constants
 from .model_entity import SgEntityModel
 
 # import the shotgun_model module from the shotgun utils framework
@@ -230,26 +230,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
         else:
             self._publish_type_field = "tank_type"
 
-        publish_fields = [self._publish_type_field,
-                          "name",
-                          "version_number",
-                          "image",
-                          "entity",
-                          "path",
-                          "description",
-                          "sg_status_list",
-                          "task",
-                          "task.Task.sg_status_list",
-                          "task.Task.due_date",
-                          "project",
-                          "task.Task.content",
-                          "created_by",
-                          "created_at",
-                          "version", # note: not supported on TankPublishedFile so always None
-                          "version.Version.sg_status_list",
-                          "created_by.HumanUser.image"
-                          ]
-
+        publish_fields = [self._publish_type_field] + constants.PUBLISHED_FILES_FIELDS
 
         # first add our folders to the model
         # make gc happy by keeping handle to all items

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -237,6 +237,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
                           "entity",
                           "path",
                           "description",
+                          "sg_status_list",
                           "task",
                           "task.Task.sg_status_list",
                           "task.Task.due_date",

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -11,7 +11,7 @@
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
-from . import utils
+from . import utils, constants
 
 # import the shotgun_model module from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
@@ -60,22 +60,7 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
             publish_type_field = "tank_type"
 
         # fields to pull down
-        fields = [publish_type_field,
-                  "name",
-                  "version_number",
-                  "image",
-                  "entity",
-                  "path",
-                  "description",
-                  "task",
-                  "task.Task.sg_status_list",
-                  "task.Task.due_date",
-                  "task.Task.content",
-                  "created_by",
-                  "created_at",
-                  "version", # note: not supported on TankPublishedFile so always None
-                  "version.Version.sg_status_list",
-                  "created_by.HumanUser.image"]
+        fields = [publish_type_field] + constants.PUBLISHED_FILES_FIELDS
 
         # when we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items


### PR DESCRIPTION
This adds the `sg_status_list` to the list of preloaded fields of published files before passing them to the `filter_publishes` hook.

This simplifies the creation of a hook that hides publishes under a certain status (e.g. filtering out publishes that are under a custom *deprecated* status) while only adding one standard preloaded field.