### PR TITLE
#31343 Apply 'filter_publishes' in Version History

### DIFF
--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -413,35 +413,14 @@ class SgLatestPublishModel(ShotgunOverlayModel):
         calculations and other manipulations of the data before it is passed on to the model
         class.
 
-        :param sg_data_list: list of shotgun dictionaries, as retunrned by the find() call.
+        :param sg_data_list: list of shotgun dictionaries, as returned by the find() call.
         :returns: should return a list of shotgun dictionaries, on the same form as the input.
         """
         app = sgtk.platform.current_bundle()
 
-        try:
-            # first, let the filter_publishes_hook have a chance to filter
-            # the list of publishes:
-
-            # Constructing a wrapper dictionary so that it's future proof to support returning
-            # additional information from the hook
-            hook_publish_list = [{"sg_publish":sg_data} for sg_data in sg_data_list]
-
-            hook_publish_list = app.execute_hook("filter_publishes_hook", publishes=hook_publish_list)
-            if not isinstance(hook_publish_list, list):
-                app.log_error("hook_filter_publishes returned an unexpected result type '%s' - ignoring!"
-                              % type(hook_publish_list).__name__)
-                hook_publish_list = []
-
-            # split back out publishes:
-            sg_data_list = []
-            for item in hook_publish_list:
-                sg_data = item.get("sg_publish")
-                if sg_data:
-                    sg_data_list.append(sg_data)
-
-        except Exception:
-            app.log_exception("Failed to execute 'filter_publishes_hook'!")
-            sg_data_list = []
+        # First, let the filter_publishes hook have a change to filter the list
+        # of publishes:
+        sg_data_list = utils.filter_publishes(app, sg_data_list)
 
         # filter the shotgun data so that we only return the latest publish for each file.
         # also perform aggregate computations and push those summaries into the associated

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -418,7 +418,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
         """
         app = sgtk.platform.current_bundle()
 
-        # First, let the filter_publishes hook have a change to filter the list
+        # First, let the filter_publishes hook have a chance to filter the list
         # of publishes:
         sg_data_list = utils.filter_publishes(app, sg_data_list)
 

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -131,6 +131,19 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
                                              sg_data["created_by"]["id"])
 
 
+    def _before_data_processing(self, sg_data_list):
+        """
+        Called just after data has been retrieved from Shotgun but before any processing
+        takes place. This makes it possible for deriving classes to perform summaries,
+        calculations and other manipulations of the data before it is passed on to the model
+        class.
+
+        :param sg_data_list: list of shotgun dictionaries, as returned by the find() call.
+        :returns: should return a list of shotgun dictionaries, on the same form as the input.
+        """
+        app = sgtk.platform.current_bundle()
+
+        return utils.filter_publishes(app, sg_data_list)
 
 
     def _populate_default_thumbnail(self, item):

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -215,7 +215,7 @@ def create_overlayed_publish_thumbnail(image):
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
         painter.setBrush(brush)
 
-        # figure out the offset height wise in order to center the thumb
+        # figure out the vertical offset in order to center the thumb
         height_difference = CANVAS_HEIGHT - thumb_scaled.height()
         width_difference = CANVAS_WIDTH - thumb_scaled.width()
 

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -215,7 +215,7 @@ def create_overlayed_publish_thumbnail(image):
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
         painter.setBrush(brush)
 
-        # figure out the vertical offset in order to center the thumb
+        # figure out the offsets in order to center the thumb
         height_difference = CANVAS_HEIGHT - thumb_scaled.height()
         width_difference = CANVAS_WIDTH - thumb_scaled.width()
 

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -238,3 +238,35 @@ def create_overlayed_publish_thumbnail(image):
     
     return base_image
     
+
+def filter_publishes(app, sg_data_list):
+    """
+    Filters a list of shotgun published files based on the filter_publishes hook.
+
+    :param app:           application that has the hook.
+    :param sg_data_list:  list of shotgun dictionaries, as returned by the find() call.
+    :returns:             list of filtered shotgun dictionaries, same form as the input.
+    """
+    try:
+        # Constructing a wrapper dictionary so that it's future proof to support returning
+        # additional information from the hook
+        hook_publish_list = [{"sg_publish":sg_data} for sg_data in sg_data_list]
+
+        hook_publish_list = app.execute_hook("filter_publishes_hook", publishes=hook_publish_list)
+        if not isinstance(hook_publish_list, list):
+            app.log_error("hook_filter_publishes returned an unexpected result type '%s' - ignoring!"
+                          % type(hook_publish_list).__name__)
+            hook_publish_list = []
+
+        # split back out publishes:
+        sg_data_list = []
+        for item in hook_publish_list:
+            sg_data = item.get("sg_publish")
+            if sg_data:
+                sg_data_list.append(sg_data)
+
+    except Exception:
+        app.log_exception("Failed to execute 'filter_publishes_hook'!")
+        sg_data_list = []
+
+    return sg_data_list

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -243,7 +243,7 @@ def filter_publishes(app, sg_data_list):
     Filters a list of shotgun published files based on the filter_publishes
     hook.
 
-    :param app:           application that has the hook.
+    :param app:           app that has the hook.
     :param sg_data_list:  list of shotgun dictionaries, as returned by the
                           find() call.
     :returns:             list of filtered shotgun dictionaries, same form as
@@ -271,7 +271,7 @@ def filter_publishes(app, sg_data_list):
             if sg_data:
                 sg_data_list.append(sg_data)
 
-    except Exception:
+    except:
         app.log_exception("Failed to execute 'filter_publishes_hook'!")
         sg_data_list = []
 

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -1,36 +1,36 @@
 # Copyright (c) 2015 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sgtk
 from sgtk.platform.qt import QtCore, QtGui
+
 
 class ResizeEventFilter(QtCore.QObject):
     """
     Utility and helper.
-    
+
     Event filter which emits a resized signal whenever
     the monitored widget resizes.
 
     You use it like this:
-    
+
     # create the filter object. Typically, it's
     # it's easiest to parent it to the object that is
     # being monitored (in this case self.ui.thumbnail)
     filter = ResizeEventFilter(self.ui.thumbnail)
-    
-    # now set up a signal/slot connection so that the 
-    # __on_thumb_resized slot gets called every time 
+
+    # now set up a signal/slot connection so that the
+    # __on_thumb_resized slot gets called every time
     # the widget is resized
     filter.resized.connect(self.__on_thumb_resized)
-    
-    # finally, install the event filter into the QT 
+
+    # finally, install the event filter into the QT
     # event system
     self.ui.thumbnail.installEventFilter(filter)
     """
@@ -41,14 +41,14 @@ class ResizeEventFilter(QtCore.QObject):
         Event filter implementation.
         For information, see the QT docs:
         http://doc.qt.io/qt-4.8/qobject.html#eventFilter
-        
+
         This will emit the resized signal (in this class)
         whenever the linked up object is being resized.
-        
+
         :param obj: The object that is being watched for events
         :param event: Event object that the object has emitted
-        :returns: Always returns False to indicate that no events 
-                  should ever be discarded by the filter. 
+        :returns: Always returns False to indicate that no events
+                  should ever be discarded by the filter.
         """
         # peek at the message
         if event.type() == QtCore.QEvent.Resize:
@@ -60,49 +60,51 @@ class ResizeEventFilter(QtCore.QObject):
 
 def create_overlayed_user_publish_thumbnail(publish_pixmap, user_pixmap):
     """
-    Creates a sqaure 75x75 thumbnail with an optional overlayed pixmap. 
+    Creates a sqaure 75x75 thumbnail with an optional overlayed pixmap.
     """
     # create a 100x100 base image
     base_image = QtGui.QPixmap(75, 75)
     base_image.fill(QtCore.Qt.transparent)
-    
+
     painter = QtGui.QPainter(base_image)
     painter.setRenderHint(QtGui.QPainter.Antialiasing)
-    
+
     # scale down the thumb
     if not publish_pixmap.isNull():
-        thumb_scaled = publish_pixmap.scaled(75, 
-                                             75, 
-                                             QtCore.Qt.KeepAspectRatioByExpanding, 
-                                             QtCore.Qt.SmoothTransformation)  
+        thumb_scaled = publish_pixmap.scaled(
+            75, 75,
+            QtCore.Qt.KeepAspectRatioByExpanding,
+            QtCore.Qt.SmoothTransformation)
 
         # now composite the thumbnail on top of the base image
         # bottom align it to make it look nice
         thumb_img = thumb_scaled.toImage()
         brush = QtGui.QBrush(thumb_img)
-        painter.save() 
+        painter.save()
         painter.setBrush(brush)
         painter.setPen(QtGui.QPen(QtCore.Qt.NoPen))
-        painter.drawRect(0, 0, 75, 75) 
+        painter.drawRect(0, 0, 75, 75)
         painter.restore()
-    
-    if user_pixmap and not user_pixmap.isNull(): 
-    
+
+    if user_pixmap and not user_pixmap.isNull():
+
         # overlay the user picture on top of the thumbnail
-        user_scaled = user_pixmap.scaled(30, 30, QtCore.Qt.KeepAspectRatioByExpanding, QtCore.Qt.SmoothTransformation)  
+        user_scaled = user_pixmap.scaled(
+            30, 30,
+            QtCore.Qt.KeepAspectRatioByExpanding,
+            QtCore.Qt.SmoothTransformation)
         user_img = user_scaled.toImage()
         user_brush = QtGui.QBrush(user_img)
-        painter.save() 
+        painter.save()
         painter.translate(42, 42)
         painter.setBrush(user_brush)
         painter.setPen(QtGui.QPen(QtCore.Qt.NoPen))
-        painter.drawRect(0,0,30,30)
+        painter.drawRect(0, 0, 30, 30)
         painter.restore()
-    
+
     painter.end()
-    
+
     return base_image
-    
 
 
 def create_overlayed_folder_thumbnail(image):
@@ -110,80 +112,78 @@ def create_overlayed_folder_thumbnail(image):
     Given a shotgun thumbnail, create a folder icon
     with the thumbnail composited on top. This will return a
     512x400 pixmap object.
-    
+
     :param image: QImage containing a thumbnail
     :returns: QPixmap with a 512x400 px image
     """
     # folder icon size
     CANVAS_WIDTH = 512
-    CANVAS_HEIGHT = 400    
-    
+    CANVAS_HEIGHT = 400
+
     # corner radius when we draw
     CORNER_RADIUS = 10
-    
-    # maximum sized canvas we can draw on *inside* the 
+
+    # maximum sized canvas we can draw on *inside* the
     # folder icon graphic
     MAX_THUMB_WIDTH = 460
     MAX_THUMB_HEIGHT = 280
 
-    # looks like there are some pyside related memory issues here relating to 
-    # referencing a resource and then operating on it. Just to be sure, make 
+    # looks like there are some pyside related memory issues here relating to
+    # referencing a resource and then operating on it. Just to be sure, make
     # make a full copy of the resource before starting to manipulate.
     base_image = QtGui.QPixmap(":/res/folder_512x400.png")
-    
+
     # now attempt to load the image
     # pixmap will be a null pixmap if load fails
     thumb = QtGui.QPixmap.fromImage(image)
-        
+
     if not thumb.isNull():
-    
-        thumb_scaled = thumb.scaled(MAX_THUMB_WIDTH, 
-                                    MAX_THUMB_HEIGHT, 
-                                    QtCore.Qt.KeepAspectRatio, 
-                                    QtCore.Qt.SmoothTransformation)  
-        
-          
+
+        thumb_scaled = thumb.scaled(MAX_THUMB_WIDTH,
+                                    MAX_THUMB_HEIGHT,
+                                    QtCore.Qt.KeepAspectRatio,
+                                    QtCore.Qt.SmoothTransformation)
+
         # now composite the thumbnail
         thumb_img = thumb_scaled.toImage()
         brush = QtGui.QBrush(thumb_img)
-    
+
         painter = QtGui.QPainter(base_image)
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
         painter.setBrush(brush)
-    
+
         # figure out the offset height wise in order to center the thumb
         height_difference = CANVAS_HEIGHT - thumb_scaled.height()
         width_difference = CANVAS_WIDTH - thumb_scaled.width()
-    
+
         inlay_offset_w = (width_difference/2)+(CORNER_RADIUS/2)
-        # add a 30 px offset here to push the image off center to 
+        # add a 30 px offset here to push the image off center to
         # fit nicely inside the folder icon
         inlay_offset_h = (height_difference/2)+(CORNER_RADIUS/2)+30
-    
+
         # note how we have to compensate for the corner radius
         painter.translate(inlay_offset_w, inlay_offset_h)
-        painter.drawRoundedRect(0,  
-                                0, 
-                                thumb_scaled.width()-CORNER_RADIUS, 
-                                thumb_scaled.height()-CORNER_RADIUS, 
-                                CORNER_RADIUS, 
+        painter.drawRoundedRect(0,
+                                0,
+                                thumb_scaled.width()-CORNER_RADIUS,
+                                thumb_scaled.height()-CORNER_RADIUS,
+                                CORNER_RADIUS,
                                 CORNER_RADIUS)
-        
+
         painter.end()
-    
+
     return base_image
-    
-        
+
 
 def create_overlayed_publish_thumbnail(image):
     """
     Given a shotgun thumbnail, create a publish icon
-    with the thumbnail composited onto a centered otherwise empty canvas. 
+    with the thumbnail composited onto a centered otherwise empty canvas.
     This will return a 512x400 pixmap object.
-    
-    
+
+
     :param image: QImage containing a thumbnail
-    :returns: QPixmap with a 512x400 px image    
+    :returns: QPixmap with a 512x400 px image
     """
 
     CANVAS_WIDTH = 512
@@ -193,69 +193,75 @@ def create_overlayed_publish_thumbnail(image):
     # get the 512 base image
     base_image = QtGui.QPixmap(CANVAS_WIDTH, CANVAS_HEIGHT)
     base_image.fill(QtCore.Qt.transparent)
-    
+
     # now attempt to load the image
-    # pixmap will be a null pixmap if load fails    
+    # pixmap will be a null pixmap if load fails
     thumb = QtGui.QPixmap.fromImage(image)
-    
+
     if not thumb.isNull():
-            
+
         # scale it down to fit inside a frame of maximum 512x512
-        thumb_scaled = thumb.scaled(CANVAS_WIDTH, 
-                                    CANVAS_HEIGHT, 
-                                    QtCore.Qt.KeepAspectRatio, 
-                                    QtCore.Qt.SmoothTransformation)  
+        thumb_scaled = thumb.scaled(CANVAS_WIDTH,
+                                    CANVAS_HEIGHT,
+                                    QtCore.Qt.KeepAspectRatio,
+                                    QtCore.Qt.SmoothTransformation)
 
         # now composite the thumbnail on top of the base image
         # bottom align it to make it look nice
         thumb_img = thumb_scaled.toImage()
         brush = QtGui.QBrush(thumb_img)
-        
+
         painter = QtGui.QPainter(base_image)
         painter.setRenderHint(QtGui.QPainter.Antialiasing)
         painter.setBrush(brush)
-        
+
         # figure out the offset height wise in order to center the thumb
         height_difference = CANVAS_HEIGHT - thumb_scaled.height()
         width_difference = CANVAS_WIDTH - thumb_scaled.width()
-        
-        # center it with wise
+
+        # center it horizontally
         inlay_offset_w = (width_difference/2)+(CORNER_RADIUS/2)
-        # bottom height wise
-        #inlay_offset_h = height_difference+CORNER_RADIUS
+        # center it vertically
         inlay_offset_h = (height_difference/2)+(CORNER_RADIUS/2)
-        
+
         # note how we have to compensate for the corner radius
         painter.translate(inlay_offset_w, inlay_offset_h)
-        painter.drawRoundedRect(0,  
-                                0, 
-                                thumb_scaled.width()-CORNER_RADIUS, 
-                                thumb_scaled.height()-CORNER_RADIUS, 
-                                CORNER_RADIUS, 
+        painter.drawRoundedRect(0,
+                                0,
+                                thumb_scaled.width()-CORNER_RADIUS,
+                                thumb_scaled.height()-CORNER_RADIUS,
+                                CORNER_RADIUS,
                                 CORNER_RADIUS)
-        
+
         painter.end()
-    
+
     return base_image
-    
+
 
 def filter_publishes(app, sg_data_list):
     """
-    Filters a list of shotgun published files based on the filter_publishes hook.
+    Filters a list of shotgun published files based on the filter_publishes
+    hook.
 
     :param app:           application that has the hook.
-    :param sg_data_list:  list of shotgun dictionaries, as returned by the find() call.
-    :returns:             list of filtered shotgun dictionaries, same form as the input.
+    :param sg_data_list:  list of shotgun dictionaries, as returned by the
+                          find() call.
+    :returns:             list of filtered shotgun dictionaries, same form as
+                          the input.
     """
     try:
-        # Constructing a wrapper dictionary so that it's future proof to support returning
-        # additional information from the hook
-        hook_publish_list = [{"sg_publish":sg_data} for sg_data in sg_data_list]
+        # Constructing a wrapper dictionary so that it's future proof to
+        # support returning additional information from the hook
+        hook_publish_list = [{"sg_publish": sg_data}
+                             for sg_data in sg_data_list]
 
-        hook_publish_list = app.execute_hook("filter_publishes_hook", publishes=hook_publish_list)
+        hook_publish_list = app.execute_hook("filter_publishes_hook",
+                                             publishes=hook_publish_list)
         if not isinstance(hook_publish_list, list):
-            app.log_error("hook_filter_publishes returned an unexpected result type '%s' - ignoring!"
-                          % type(hook_publish_list).__name__)
+            app.log_error(
+                "hook_filter_publishes returned an unexpected result type \
+                '%s' - ignoring!"
+                % type(hook_publish_list).__name__)
             hook_publish_list = []
 
         # split back out publishes:


### PR DESCRIPTION
The `filter_publishes` hook is only applied to the main published files view and not to the version history (in the details section). This behaviour is not really intuitive as one might expect the filter to affect the entire list of publishes, no matter where or how it is represented. This PR makes it so that the hook is also called for the version history.

Done by factoring out the filtering logic to a `utils.py` function, to reduce redundancy.

Also took the opportunity to make `utils.py` PEP8 compliant and fix (what I think are) various minor typos.