### PR TITLE
#33202 Upgrade to use new frameworks

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -141,5 +141,5 @@ requires_engine_version:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
-    - {"name": "tk-framework-qtwidgets", "version": "v1.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v3.x.x"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -15,7 +15,7 @@ from sgtk.platform.qt import QtCore, QtGui
  
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
-shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_view")
+shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_history import Ui_PublishHistoryWidget
 
@@ -119,7 +119,7 @@ class PublishHistoryWidget(QtGui.QWidget):
 
 
 
-class SgPublishHistoryDelegate(shotgun_view.WidgetDelegate):
+class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
     """
     Delegate which 'glues up' the Details Widget with a QT View.
     """
@@ -131,7 +131,7 @@ class SgPublishHistoryDelegate(shotgun_view.WidgetDelegate):
         :param view: The view where this delegate is being used
         :param action_manager: Action manager instance
         """                
-        shotgun_view.WidgetDelegate.__init__(self, view)
+        shotgun_view.EditSelectedWidgetDelegate.__init__(self, view)
         self._status_model = status_model
         self._action_manager = action_manager
         

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -15,7 +15,7 @@ from .model_latestpublish import SgLatestPublishModel
 
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
-shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_view")
+shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_list import Ui_PublishListWidget
 
@@ -120,7 +120,7 @@ class PublishListWidget(QtGui.QWidget):
 
 
 
-class SgPublishListDelegate(shotgun_view.WidgetDelegate):
+class SgPublishListDelegate(shotgun_view.EditSelectedWidgetDelegate):
     """
     Delegate which 'glues up' the List widget with a QT View.
     """
@@ -135,7 +135,7 @@ class SgPublishListDelegate(shotgun_view.WidgetDelegate):
         self._action_manager = action_manager
         self._view = view
         self._sub_items_mode = False
-        shotgun_view.WidgetDelegate.__init__(self, view)
+        shotgun_view.EditSelectedWidgetDelegate.__init__(self, view)
 
     def set_sub_items_mode(self, enabled):
         """

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -16,7 +16,7 @@ from .utils import ResizeEventFilter
 
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
-shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_view")
+shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_thumb import Ui_PublishThumbWidget
 
@@ -143,7 +143,7 @@ class PublishThumbWidget(QtGui.QWidget):
             self.ui.thumbnail.resize(new_size.width(), calc_height)
 
 
-class SgPublishThumbDelegate(shotgun_view.WidgetDelegate):
+class SgPublishThumbDelegate(shotgun_view.EditSelectedWidgetDelegate):
     """
     Delegate which 'glues up' the Thumb widget with a QT View.
     """
@@ -158,7 +158,7 @@ class SgPublishThumbDelegate(shotgun_view.WidgetDelegate):
         self._action_manager = action_manager
         self._view = view
         self._sub_items_mode = False
-        shotgun_view.WidgetDelegate.__init__(self, view)
+        shotgun_view.EditSelectedWidgetDelegate.__init__(self, view)
 
     def set_sub_items_mode(self, enabled):
         """

--- a/python/tk_multi_loader/model_entity.py
+++ b/python/tk_multi_loader/model_entity.py
@@ -12,7 +12,7 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
 # import the shotgun_model module from the shotgun utils framework
-shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model") 
+shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 ShotgunOverlayModel = shotgun_model.ShotgunOverlayModel 
 
 class SgEntityModel(ShotgunOverlayModel):
@@ -21,7 +21,7 @@ class SgEntityModel(ShotgunOverlayModel):
     on the left hand side.
     """
     
-    def __init__(self, parent, overlay_widget, entity_type, filters, hierarchy):
+    def __init__(self, parent, overlay_widget, entity_type, filters, hierarchy, bg_task_manager):
         """
         Constructor
         """
@@ -47,7 +47,8 @@ class SgEntityModel(ShotgunOverlayModel):
                                      overlay_widget, 
                                      download_thumbs=False, 
                                      schema_generation=4,
-                                     bg_load_thumbs=True)
+                                     bg_load_thumbs=True,
+                                     bg_task_manager=bg_task_manager)
         fields=["image", "sg_status_list", "description"]
         self._load_data(entity_type, filters, hierarchy, fields)
     

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -13,7 +13,6 @@ from sgtk.platform.qt import QtCore, QtGui
 
 import sgtk
 from . import utils, constants
-from .model_entity import SgEntityModel
 
 # import the shotgun_model module from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
@@ -34,7 +33,7 @@ class SgLatestPublishModel(ShotgunOverlayModel):
     PUBLISH_TYPE_NAME_ROLE = QtCore.Qt.UserRole + 104
     SEARCHABLE_NAME = QtCore.Qt.UserRole + 105
 
-    def __init__(self, parent, overlay_widget, publish_type_model):
+    def __init__(self, parent, overlay_widget, publish_type_model, bg_task_manager):
         """
         Model which represents the latest publishes for an entity
         """
@@ -53,7 +52,8 @@ class SgLatestPublishModel(ShotgunOverlayModel):
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
                                      schema_generation=6,
-                                     bg_load_thumbs=True)
+                                     bg_load_thumbs=True,
+                                     bg_task_manager=bg_task_manager)
 
     ############################################################################################
     # public interface
@@ -271,9 +271,6 @@ class SgLatestPublishModel(ShotgunOverlayModel):
         self._folder_items = []
         self._associated_items = {}
 
-
-
-
         for tree_view_item in self._treeview_folder_items:
 
             # compute and store a hash for the tree view item so that we can access it later
@@ -351,9 +348,6 @@ class SgLatestPublishModel(ShotgunOverlayModel):
             # exclude v112:s
             search_str += " v%03d" % sg_data["version_number"]
         item.setData(search_str, SgLatestPublishModel.SEARCHABLE_NAME)
-
-
-
 
     def _populate_default_thumbnail(self, item):
         """

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -25,7 +25,7 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
     USER_THUMB_ROLE = QtCore.Qt.UserRole + 101
     PUBLISH_THUMB_ROLE = QtCore.Qt.UserRole + 102
 
-    def __init__(self, parent, overlay_widget):
+    def __init__(self, parent, overlay_widget, bg_task_manager):
         """
         Constructor
         """
@@ -37,7 +37,8 @@ class SgPublishHistoryModel(ShotgunOverlayModel):
                                      overlay_widget,
                                      download_thumbs=app.get_setting("download_thumbnails"),
                                      schema_generation=2,
-                                     bg_load_thumbs=True)
+                                     bg_load_thumbs=True,
+                                     bg_task_manager=bg_task_manager)
 
 
     ############################################################################################

--- a/python/tk_multi_loader/model_publishtype.py
+++ b/python/tk_multi_loader/model_publishtype.py
@@ -32,7 +32,7 @@ class SgPublishTypeModel(ShotgunOverlayModel):
     
     FOLDERS_ITEM_TEXT = "Folders"
     
-    def __init__(self, parent, overlay_widget, action_manager, settings_manager):
+    def __init__(self, parent, overlay_widget, action_manager, settings_manager, bg_task_manager):
         """
         Constructor
         """
@@ -41,7 +41,8 @@ class SgPublishTypeModel(ShotgunOverlayModel):
                                      overlay_widget, 
                                      download_thumbs=False,
                                      schema_generation=2,
-                                     bg_load_thumbs=True)
+                                     bg_load_thumbs=True,
+                                     bg_task_manager=bg_task_manager)
         
         self._action_manager = action_manager
         self._settings_manager = settings_manager

--- a/python/tk_multi_loader/model_status.py
+++ b/python/tk_multi_loader/model_status.py
@@ -20,12 +20,15 @@ class SgStatusModel(ShotgunModel):
     This model represents status codes.
     """
     
-    def __init__(self, parent):
+    def __init__(self, parent, bg_task_manager):
         """
         Constructor
         """
         # folder icon
-        ShotgunModel.__init__(self, parent, download_thumbs=False)
+        ShotgunModel.__init__(self, 
+                              parent, 
+                              download_thumbs=False, 
+                              bg_task_manager=bg_task_manager)
         fields=["bg_color", "icon", "code", "name"]
         self._load_data("Status", [], ["code"], fields)
         self._refresh_data()


### PR DESCRIPTION
This upgrades the loader to use shotgunutils v3 and qtwidgets v2. It also sets up a single task manager shared across all models.