### PR TITLE
33063 Add user activity metrics calls

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -139,6 +139,8 @@ requires_shotgun_version:
 requires_core_version: "v0.16.32"
 requires_engine_version:
 
+# XXX will require core that supports metrics logging
+
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}

--- a/info.yml
+++ b/info.yml
@@ -139,8 +139,6 @@ requires_shotgun_version:
 requires_core_version: "v0.16.32"
 requires_engine_version:
 
-# XXX will require core that supports metrics logging
-
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}

--- a/python/tk_multi_loader/loader_action_manager.py
+++ b/python/tk_multi_loader/loader_action_manager.py
@@ -204,6 +204,8 @@ class LoaderActionManager(ActionManager):
         except Exception, e:
             self._app.log_exception("Could not execute execute_action hook.")
             QtGui.QMessageBox.critical(None, "Hook Error", "Error: %s" % e)
+        else:
+            self._app.log_metric("%s action" % (action_name,))
     
     def _show_in_sg(self, entity):
         """

--- a/python/tk_multi_loader/loader_action_manager.py
+++ b/python/tk_multi_loader/loader_action_manager.py
@@ -205,7 +205,11 @@ class LoaderActionManager(ActionManager):
             self._app.log_exception("Could not execute execute_action hook.")
             QtGui.QMessageBox.critical(None, "Hook Error", "Error: %s" % e)
         else:
-            self._app.log_metric("%s action" % (action_name,))
+            try:
+                self._app.log_metric("%s action" % (action_name,))
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
     
     def _show_in_sg(self, entity):
         """


### PR DESCRIPTION
The calls log the metrics internally and ignore any errors. This prevents the need to force the app/fw users to update to a new core that supports metrics. When a supported core is updated, the metrics will be logged.