### PR TITLE
Accounts for receiving datetime.datetime objects from SG.

### DIFF
--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -331,7 +331,11 @@ class SgPublishThumbDelegate(shotgun_view.EditSelectedWidgetDelegate):
             tooltip =  "<b>Name:</b> %s" % (sg_data.get("code") or "No name given.")
             # Version 012 by John Smith at 2014-02-23 10:34            
             created_unixtime = sg_data.get("created_at") or 0
-            date_str = datetime.datetime.fromtimestamp(created_unixtime).strftime('%Y-%m-%d %H:%M')
+
+            if isinstance(created_unixtime, datetime.datetime):
+                date_str = created_unixtime.strftime('%Y-%m-%d %H:%M')
+            else:
+                date_str = datetime.datetime.fromtimestamp(str(created_unixtime)).strftime('%Y-%m-%d %H:%M')
 
             # created_by is set to None if the user has been deleted.
             if sg_data.get("created_by") and sg_data["created_by"].get("name"):

--- a/python/tk_multi_loader/loader_action_manager.py
+++ b/python/tk_multi_loader/loader_action_manager.py
@@ -107,7 +107,9 @@ class LoaderActionManager(ActionManager):
 
         # convert created_at unix time stamp to shotgun std time stamp
         unix_timestamp = sg_data.get("created_at")
-        if unix_timestamp:
+        if unix_timestamp and isinstance(unix_timestamp, datetime.datetime):
+            sg_data["created_at"] = unix_timestamp
+        elif unix_timestamp:
             sg_timestamp = datetime.datetime.fromtimestamp(unix_timestamp, 
                                                            shotgun_api3.sg_timezone.LocalTimezone())
             sg_data["created_at"] = sg_timestamp


### PR DESCRIPTION
This cropped up during Max 2017 compatibility testing. Passing a datetime object to the string formatter results in a TypeError being raised. Handling it here in a backwards-compatible way.