### PR TITLE
#38761 Tree view sorted alphabetically

### DIFF
--- a/python/tk_multi_loader/proxymodel_entity.py
+++ b/python/tk_multi_loader/proxymodel_entity.py
@@ -15,7 +15,10 @@ shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "sho
 
 class SgEntityProxyModel(QtGui.QSortFilterProxyModel):
     """
-    Filter model to be used in conjunction with SgEntityModel
+    Filter model to be used in conjunction with SgEntityModel,
+    left hand side loader tree views and the search input box
+    in the UI. This proxy model sorts items in alphabetical order
+    and culls entries based on the current search phrase.
     """
 
     def __init__(self, parent):


### PR DESCRIPTION
The left hand side tree view is now shorted alphabetically:

![image](https://cloud.githubusercontent.com/assets/337710/20429035/1d4a7180-ad84-11e6-9e57-3e3fa9fe6ede.png)

Previously, it would just display the raw data as it was being sent from the shotgun model. The shotgun model does not imply any ordering of the data, this is left to the client to handle (since it typically varies between use cases and sometimes, like in the case of the loader, you want to do a bunch of post processing of the raw model data before you have access to the display name which you want to order by).