### PR TITLE
#39260 filter support for new shotgun model

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -141,5 +141,5 @@ requires_engine_version:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v4.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}
     - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}

--- a/python/tk_multi_loader/constants.py
+++ b/python/tk_multi_loader/constants.py
@@ -35,4 +35,4 @@ PUBLISHED_FILES_FIELDS = ["name",
 
 # left hand side tree view search only kicks in
 # after a certain number have been typed in.
-TREE_SEARCH_TRIGGER_LENGTH = 1
+TREE_SEARCH_TRIGGER_LENGTH = 2

--- a/python/tk_multi_loader/constants.py
+++ b/python/tk_multi_loader/constants.py
@@ -32,3 +32,7 @@ PUBLISHED_FILES_FIELDS = ["name",
                           "version.Version.sg_status_list",
                           "created_by.HumanUser.image"
                           ]
+
+# left hand side tree view search only kicks in
+# after a certain number have been typed in.
+TREE_SEARCH_TRIGGER_LENGTH = 1

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1280,7 +1280,7 @@ class AppDialog(QtGui.QWidget):
         # change UI decorations based on new pattern.
         # for performance, make sure filtering only kicks in
         # once we have typed at least one character
-        if pattern and len(pattern) > constants.TREE_SEARCH_TRIGGER_LENGTH:
+        if pattern and len(pattern) >= constants.TREE_SEARCH_TRIGGER_LENGTH:
             # indicate with a blue border that a search is active
             tree_view.setStyleSheet("""QTreeView { border-width: 3px;
                                                    border-style: solid;

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1276,7 +1276,9 @@ class AppDialog(QtGui.QWidget):
         proxy_model.setFilterFixedString(pattern)
 
         # change UI decorations based on new pattern.
-        if pattern and len(pattern) > 0:
+        # for performance, make sure filtering only kicks in
+        # once we have typed at least one character
+        if pattern and len(pattern) > 1:
             # indicate with a blue border that a search is active
             tree_view.setStyleSheet("""QTreeView { border-width: 3px;
                                                    border-style: solid;

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -25,6 +25,8 @@ from .model_publishhistory import SgPublishHistoryModel
 from .delegate_publish_history import SgPublishHistoryDelegate
 from .search_widget import SearchWidget
 
+from . import constants
+
 from .ui.dialog import Ui_Dialog
 
 # import frameworks
@@ -1278,7 +1280,7 @@ class AppDialog(QtGui.QWidget):
         # change UI decorations based on new pattern.
         # for performance, make sure filtering only kicks in
         # once we have typed at least one character
-        if pattern and len(pattern) > 1:
+        if pattern and len(pattern) > constants.TREE_SEARCH_TRIGGER_LENGTH:
             # indicate with a blue border that a search is active
             tree_view.setStyleSheet("""QTreeView { border-width: 3px;
                                                    border-style: solid;

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1279,7 +1279,7 @@ class AppDialog(QtGui.QWidget):
 
         # change UI decorations based on new pattern.
         # for performance, make sure filtering only kicks in
-        # once we have typed at least one character
+        # once we have typed a couple of characters
         if pattern and len(pattern) >= constants.TREE_SEARCH_TRIGGER_LENGTH:
             # indicate with a blue border that a search is active
             tree_view.setStyleSheet("""QTreeView { border-width: 3px;

--- a/python/tk_multi_loader/proxymodel_entity.py
+++ b/python/tk_multi_loader/proxymodel_entity.py
@@ -11,6 +11,8 @@
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
+from . import constants
+
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
 class SgEntityProxyModel(QtGui.QSortFilterProxyModel):
@@ -86,7 +88,7 @@ class SgEntityProxyModel(QtGui.QSortFilterProxyModel):
         self._cache_hits = 0
         self._cache = {}
 
-        if len(pattern) > 1:
+        if len(pattern) > constants.TREE_SEARCH_TRIGGER_LENGTH:
             # we have a search filter that is longer than one character.
             # start filtering. Before we can filter, ensure that the entire
             # data set is loaded in the tree.

--- a/python/tk_multi_loader/proxymodel_entity.py
+++ b/python/tk_multi_loader/proxymodel_entity.py
@@ -88,22 +88,14 @@ class SgEntityProxyModel(QtGui.QSortFilterProxyModel):
         self._cache_hits = 0
         self._cache = {}
 
-        if len(pattern) > constants.TREE_SEARCH_TRIGGER_LENGTH:
+        if len(pattern) >= constants.TREE_SEARCH_TRIGGER_LENGTH:
             # we have a search filter that is longer than one character.
             # start filtering. Before we can filter, ensure that the entire
             # data set is loaded in the tree.
 
-            def __fetch_more_r(index):
-                if self.canFetchMore(index):
-                    self.fetchMore(index)
-                for idx in range(self.rowCount(index)):
-                    child_idx = self.index(idx, 0, index)
-                    __fetch_more_r(child_idx)
-
-            root_index = self.sourceModel().invisibleRootItem().index()
-
+            # ensure model is fully loaded before we attempt any searching
             app.log_debug("Loading up all nodes in tree so we can search...")
-            __fetch_more_r(self.mapFromSource(root_index))
+            self.sourceModel().ensure_data_is_loaded()
             app.log_debug("...done")
 
             # call base class


### PR DESCRIPTION
This updates the loader to work correctly with the new optimized shotgun model that defer loads things into memory.

- the filtering is 'capped' so that it doesn't kick in until you have typed 2 characters.
- the entire tree is loaded into memory at this point in order for the proxy model to operate.

