### PR TITLE
#37239: Use the new tree widget for Loader hierarchy navigation.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -76,7 +76,13 @@ configuration:
 
     entities:
         default_value:
+            - caption: Project
+              type: Hierarchy
+              root: "/Project/{context.project.id}"
+              publish_filters: []
+
             - caption: Assets
+              type: Query
               entity_type: Asset
               publish_filters: []
               filters:
@@ -84,6 +90,7 @@ configuration:
               hierarchy: [sg_asset_type, code]
 
             - caption: Shots
+              type: Query
               entity_type: Shot
               publish_filters: []
               filters:
@@ -91,6 +98,7 @@ configuration:
               hierarchy: [sg_sequence, code]
 
             - caption: My Tasks
+              type: Query
               entity_type: Task
               publish_filters: []
               filters:
@@ -98,14 +106,17 @@ configuration:
               - ["project", "is", "{context.project}"]
               hierarchy: [entity, content]
 
-
         type: list
         description: "This setting defines the different tabs that will show up on the left hand side.
                       Each tab represents a Shotgun query, grouped by some shotgun fields to form a tree. 
-                      This setting is a list of dictionaries. Each dictionary in the list defines one tab,
-                      and should have they following keys: *caption* specifies the name of the tab, *entity_type*
-                      specifies the shotgun entity type to display. *filters* is a list of standard API Shotgun 
-                      filters. *hierarchy* is a list of shotgun fields, defining the grouping of the tree.
+                      This setting is a list of dictionaries. Each dictionary in the list defines one tab.
+                      Dictionaries with their *type* key set to 'Hierarchy' should have they following keys:
+                      *caption* specifies the name of the tab, *root* specifies the path to the root
+                      of the project hierarchy to display.
+                      Dictionaries with their *type* key set to 'Query' should have they following keys:
+                      *caption* specifies the name of the tab, *entity_type* specifies the shotgun entity
+                      type to display. *filters* is a list of standard API Shotgun filters.
+                      *hierarchy* is a list of shotgun fields, defining the grouping of the tree.
                       Optionally, you can specify a *publish_filters* key, containing shotgun API filters to
                       apply to the publishes listing as it is being loaded in the main view." 
         allows_empty: False

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -19,6 +19,7 @@ shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_list import Ui_PublishListWidget
 from .delegate_publish import PublishWidget, PublishDelegate
+from . import model_item_data
 
 class PublishListWidget(PublishWidget):
     """
@@ -73,36 +74,12 @@ class SgPublishListDelegate(PublishDelegate):
         
         :param model_index: Model index to process
         :param widget: widget to adjust
-        """        
-        sg_data = shotgun_model.get_sg_data(model_index)
-        field_data = shotgun_model.get_sanitized_data(model_index, 
-                                                      shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
+        """
 
-        # examples of data. In the examples below, when we say "node", this 
-        # means a node in the tree structure in the left hand side tree
-        
-        # intermediate node which isn't a link 
-        # field_data: {'name': 'sg_asset_type', 'value': 'Character' }
-        # sg_data:    None
-        
-        # intermediate node which is an entity
-        # field_data: {'name': 'sg_sequence', 'value': {'type': 'Sequence', 'id': 11, 'name': 'bunny_080'}}
-        # sg_data:    None
-        
-        # leaf node:  
-        # field_data: {'name': 'code', 'value': 'aaa_0030'}
-        # sg_data: {'code': 'aaa_00030',
-        #           'description': 'Created by the Shotgun Flame exporter.',
-        #           'id': 1662,
-        #           'image': 'https://....',
-        #           'project': {'id': 289, 'name': 'Climp', 'type': 'Project'},
-        #           'sg_sequence': {'id': 202, 'name': 'aaa', 'type': 'Sequence'},
-        #           'sg_status_list': 'wtg',
-        #           'type': 'Shot'}
-        
-        field_value = field_data["value"]
-        
-        # by default, just display the value 
+        # Extract the Shotgun data and field value from the model index.
+        (sg_data, field_value) = model_item_data.get_item_data(model_index)
+
+        # by default, just display the value
         main_text = field_value
         small_text = ""
 
@@ -115,7 +92,7 @@ class SgPublishListDelegate(PublishDelegate):
             # this can be a multi link field but also a field like a tags field or a non-entity link type field.
             formatted_values = []
             formatted_types = set()
-            
+
             for v in field_value:
                 if isinstance(v, dict) and "name" in v and "type" in v:
                     # This is a link field
@@ -125,7 +102,7 @@ class SgPublishListDelegate(PublishDelegate):
                         formatted_types.add(v["type"])
                 else:
                     formatted_values.append(str(v))
-            
+
             types = ", ".join(list(formatted_types))
             names = ", ".join(formatted_values)
             main_text = "<b>%s</b><br>%s" % (types, names)

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -20,6 +20,7 @@ shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_thumb import Ui_PublishThumbWidget
 from .delegate_publish import PublishWidget, PublishDelegate
+from . import model_item_data
 
 class PublishThumbWidget(PublishWidget):
     """
@@ -78,22 +79,12 @@ class SgPublishThumbDelegate(PublishDelegate):
         :param model_index: Index of the item being drawn by the delegate.
         :param widget: Qt widget created by the delegate for rendering.
         """
-        # this is a publish!
-        sg_data = shotgun_model.get_sg_data(model_index)
+
+        # Extract the Shotgun data and field value from the model index.
+        (sg_data, field_value) = model_item_data.get_item_data(model_index)
 
         header_text = ""
         details_text = ""
-
-        # this is a folder item, injected into the publish model from the entity tree
-
-        field_data = shotgun_model.get_sanitized_data(model_index,
-                                                      shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-        # examples of data:
-        # intermediate node: {'name': 'sg_asset_type', 'value': 'Character' }
-        # intermediate node: {'name': 'sg_sequence',   'value': {'type': 'Sequence', 'id': 11, 'name': 'bunny_080'}}
-        # leaf node:         {'name': 'code',          'value': 'mystuff'}
-
-        field_value = field_data["value"]
 
         if isinstance(field_value, dict) and "name" in field_value and "type" in field_value:
             # intermediate node with entity link

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -22,13 +22,46 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
     hierarchy tree view tabs on the left-hand-side of the dialog.
     """
 
+    def __init__(self, parent, path=None, bg_task_manager=None):
+        """
+        Initializes a Shotgun Hierarchy model instance and loads a hierarchy
+        that leads to entities that are linked via the ``PublishedFile.entity`` field.
+
+        :param parent: The model parent.
+        :type parent: :class:`~PySide.QtGui.QObject`
+        :param str path: The path to the root of the hierarchy to display.
+                         This corresponds to the ``path`` argument of the
+                         :meth:`~shotgun-api3:shotgun_api3.Shotgun.nav_expand()` API method.
+                         For example, ``/Project/65`` would correspond to a project on your
+                         Shotgun site with id ``65``. By default, this value is ``None``
+                         and the project from the current project will be used. If no project
+                         can be determined, the path will default to ``/`` and
+                         all projects will be represented as top-level items in the model.
+        :param bg_task_manager: Background task manager to use for any asynchronous work.
+                                If this is ``None`` a task manager will be created as needed.
+        :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
+        """
+
+        SimpleShotgunHierarchyModel.__init__(self, parent, bg_task_manager=bg_task_manager)
+
+        # We need to provide a dictionary that identifies what additional fields to include
+        # for the loaded hierarchy leaf entities in addition to "id" and "type".
+        # When they are available for an entity, these fields will be used to add info in the detail panel.
+        # TODO: Our entity type list for entities with publishes should be retrieved from somewhere.
+        entity_fields = {}
+        for entity_type in ["Asset", "Shot"]:
+            entity_fields[entity_type] = ["code", "description", "image", "sg_status_list"]
+
+        # Load a hierarchy that leads to entities that are linked via the "PublishedFile.entity" field.
+        self.load_data("PublishedFile.entity", path=path, entity_fields=entity_fields)
+
     def reload_data(self):
         """
         Convenience method that reloads Shotgun data into the model
         using the latest parameter values passed to :meth:`load_data()`.
         """
 
-        super(SimpleShotgunHierarchyModel, self)._load_data(
+        self.load_data(
             self._seed_entity_field,
             path=self._path,
             entity_fields=self._entity_fields

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
+
+SimpleShotgunHierarchyModel = shotgun_model.SimpleShotgunHierarchyModel
+
+
+class SgHierarchyModel(SimpleShotgunHierarchyModel):
+    """
+    Wrapper around the Simple Shotgun Hierarchy model to implement
+    convenience methods used when displaying the data inside
+    hierarchy tree view tabs on the left-hand-side of the dialog.
+    """
+
+    def reload_data(self):
+        """
+        Convenience method that reloads Shotgun data into the model
+        using the latest parameter values passed to :meth:`load_data()`.
+        """
+
+        super(SimpleShotgunHierarchyModel, self)._load_data(
+            self._seed_entity_field,
+            path=self._path,
+            entity_fields=self._entity_fields
+        )

--- a/python/tk_multi_loader/model_item_data.py
+++ b/python/tk_multi_loader/model_item_data.py
@@ -10,7 +10,7 @@
 
 import sgtk
 from sgtk import TankError
-from sgtk.platform.qt import QtCore
+from sgtk.platform.qt import QtCore, QtGui
 
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
@@ -43,24 +43,40 @@ def get_item_data(item):
     #       plus "description", "image" and "sg_status_list".
     #
     # Example for a ShotgunModel asset leaf item:
-    #     {'id':             1230,
-    #      'type':           'Asset',
-    #      'code':           'Bunny',
-    #      'project':        {'id': 70, 'name': 'Demo: Animation', 'type': 'Project'},
-    #      'sg_asset_type':  'Character',
-    #      'description':    '...',
-    #      'image':          'https://...',
-    #      'sg_status_list': 'fin'}
+    # {
+    #     'id': 1230,
+    #     'type': 'Asset',
+    #     'code': 'Bunny',
+    #     'project': {
+    #         'id': 70,
+    #         'name': 'Demo: Animation',
+    #         'type': 'Project'
+    #     },
+    #     'sg_asset_type': 'Character',
+    #     'description': '...',
+    #     'image': 'https://...',
+    #     'sg_status_list': 'fin'
+    # }
     #
     # Example for a ShotgunModel shot leaf item:
-    #     {'id':             862,
-    #      'type':           'Shot',
-    #      'code':           'bunny_010_0010',
-    #      'project':        {'id': 70, 'name': 'Demo: Animation', 'type': 'Project'},
-    #      'sg_sequence':    {'id': 23, 'name': 'bunny_010', 'type': 'Sequence'},
-    #      'description':    '...',
-    #      'image':          'https://s...',
-    #      'sg_status_list': 'fin'}
+    # {
+    #     'id': 862,
+    #     'type': 'Shot',
+    #     'code': 'bunny_010_0010',
+    #     'project': {
+    #         'id': 70,
+    #         'name': 'Demo: Animation',
+    #         'type': 'Project'
+    #     },
+    #     'sg_sequence': {
+    #         'id': 23,
+    #         'name': 'bunny_010',
+    #         'type': 'Sequence'
+    #     },
+    #     'description': '...',
+    #     'image': 'https://s...',
+    #     'sg_status_list': 'fin'
+    # }
     #
     # For an item in the ShotgunHierarchyModel tree structure,
     # this data is a dictionary with these keys among others:
@@ -69,29 +85,59 @@ def get_item_data(item):
     #       "kind" and "value"
     #
     # Example for a ShotgunHierarchyModel intermediate item (without any extra entity fields requested):
-    #     {'has_children':    True,
-    #      'label':           'Character',
-    #      'path':            '/Project/70/Asset/sg_asset_type/Character',
-    #      'ref':             {'kind': 'list', 'value': 'Character'},
-    #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character',
-    #                                                         'preset_name': 'NAV_ENTRIES',
-    #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
-    #                          'type': 'PublishedFile'}}
+    # {
+    #     'has_children': True,
+    #     'label': 'Character',
+    #     'path': '/Project/70/Asset/sg_asset_type/Character',
+    #     'ref': {
+    #         'kind': 'list',
+    #         'value': 'Character'
+    #     },
+    #     'target_entities': {
+    #         'additional_filter_presets': [
+    #             {
+    #                 'path': '/Project/70/Asset/sg_asset_type/Character',
+    #                 'preset_name': 'NAV_ENTRIES',
+    #                 'seed': {
+    #                     'field': 'entity',
+    #                     'type': 'PublishedFile'
+    #                 }
+    #             }
+    #         ],
+    #         'type': 'PublishedFile'
+    #     }
+    # }
     #
     # Example for a ShotgunHierarchyModel leaf item (with the extra entity fields requested):
-    #     {'has_children':    False,
-    #      'label':           'Bunny',
-    #      'path':            '/Project/70/Asset/sg_asset_type/Character/id/1230',
-    #      'ref':             {'kind': 'entity', 'value': {'id':             1230,
-    #                                                      'type':           'Asset',
-    #                                                      'code':           'Bunny',
-    #                                                      'description':    '...',
-    #                                                      'image':          '/thumbnail/Asset/1230?567',
-    #                                                      'sg_status_list': 'fin'}},
-    #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character/id/1230',
-    #                                                         'preset_name': 'NAV_ENTRIES',
-    #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
-    #                          'type': 'PublishedFile'}}
+    # {
+    #     'has_children': False,
+    #     'label': 'Bunny',
+    #     'path': '/Project/70/Asset/sg_asset_type/Character/id/1230',
+    #     'ref': {
+    #         'kind': 'entity',
+    #         'value': {
+    #             'id': 1230,
+    #             'type': 'Asset',
+    #             'code': 'Bunny',
+    #             'description': '...',
+    #             'image': '/thumbnail/Asset/1230?567',
+    #             'sg_status_list': 'fin'
+    #         }
+    #     },
+    #     'target_entities': {
+    #         'additional_filter_presets': [
+    #             {
+    #                 'path': '/Project/70/Asset/sg_asset_type/Character/id/1230',
+    #                 'preset_name': 'NAV_ENTRIES',
+    #                 'seed': {
+    #                     'field': 'entity',
+    #                     'type': 'PublishedFile'
+    #                 }
+    #             }
+    #         ],
+    #         'type': 'PublishedFile'
+    #     }
+    # }
     #
     sg_data = shotgun_model.get_sg_data(item)
 
@@ -116,22 +162,53 @@ def get_item_data(item):
     #
     field_data = shotgun_model.get_sanitized_data(item, shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
 
-    if field_data is None and \
-       isinstance(sg_data, dict) and "has_children" in sg_data and "ref" in sg_data and \
-       isinstance(sg_data["ref"], dict) and "value" in sg_data["ref"]:
+    # Ascertain the type of the model the item is coming from.
+    # Beware that "ShotgunHierarchyItem" is a subclass of "ShotgunStandardItem".
+    if isinstance(item, shotgun_model.ShotgunHierarchyItem):
+        type_hierarchy = True
+    elif isinstance(item, shotgun_model.ShotgunStandardItem):
+        type_hierarchy = False
+    elif isinstance(item, QtCore.QModelIndex):
+        model = item.model()
+        if isinstance(model, QtGui.QAbstractProxyModel):
+            model = model.sourceModel()
+        if isinstance(model, shotgun_model.ShotgunHierarchyModel):
+            type_hierarchy = True
+        elif isinstance(model, shotgun_model.ShotgunModel):
+            type_hierarchy = False
+        else:
+            raise TankError("Unknown item '%s' model type '%s'!" % (text_data, type(model)))
+    else:
+        raise TankError("Unknown item '%s' type '%s'!" % (text_data, type(item)))
+
+    if type_hierarchy:
         # We have a ShotgunHierarchyModel item.
 
         if sg_data["has_children"]:
             # We have an intermediate item.
             # For example:
-            #     {'has_children':    True,
-            #      'label':           'Character',
-            #      'path':            '/Project/70/Asset/sg_asset_type/Character',
-            #      'ref':             {'kind': 'list', 'value': 'Character'},
-            #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character',
-            #                                                         'preset_name': 'NAV_ENTRIES',
-            #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
-            #                          'type': 'PublishedFile'}}
+            # {
+            #     'has_children': True,
+            #     'label': 'Character',
+            #     'path': '/Project/70/Asset/sg_asset_type/Character',
+            #     'ref': {
+            #         'kind': 'list',
+            #         'value': 'Character'
+            #     },
+            #     'target_entities': {
+            #         'additional_filter_presets': [
+            #             {
+            #                 'path': '/Project/70/Asset/sg_asset_type/Character',
+            #                 'preset_name': 'NAV_ENTRIES',
+            #                 'seed': {
+            #                     'field': 'entity',
+            #                     'type': 'PublishedFile'
+            #                 }
+            #             }
+            #         ],
+            #         'type': 'PublishedFile'
+            #     }
+            # }
 
             # Standardize its Shotgun data and field value.
             ref_value = sg_data["ref"]["value"]
@@ -150,39 +227,54 @@ def get_item_data(item):
         else:
             # We have a leaf item.
             # For example:
-            #     {'has_children':    False,
-            #      'label':           'Bunny',
-            #      'path':            '/Project/70/Asset/sg_asset_type/Character/id/1230',
-            #      'ref':             {'kind': 'entity', 'value': {'id':             1230,
-            #                                                      'type':           'Asset',
-            #                                                      'code':           'Bunny',
-            #                                                      'description':    '...',
-            #                                                      'image':          '/thumbnail/Asset/1230?567',
-            #                                                      'sg_status_list': 'fin'}},
-            #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character/id/1230',
-            #                                                         'preset_name': 'NAV_ENTRIES',
-            #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
-            #                          'type': 'PublishedFile'}}
+            # {
+            #     'has_children': False,
+            #     'label': 'Bunny',
+            #     'path': '/Project/70/Asset/sg_asset_type/Character/id/1230',
+            #     'ref': {
+            #         'kind': 'entity',
+            #         'value': {
+            #             'id': 1230,
+            #             'type': 'Asset',
+            #             'code': 'Bunny',
+            #             'description': '...',
+            #             'image': '/thumbnail/Asset/1230?567',
+            #             'sg_status_list': 'fin'
+            #         }
+            #     },
+            #     'target_entities': {
+            #         'additional_filter_presets': [
+            #             {
+            #                 'path': '/Project/70/Asset/sg_asset_type/Character/id/1230',
+            #                 'preset_name': 'NAV_ENTRIES',
+            #                 'seed': {
+            #                     'field': 'entity',
+            #                     'type': 'PublishedFile'
+            #                 }
+            #             }
+            #         ],
+            #         'type': 'PublishedFile'
+            #     }
+            # }
 
             # Standardize its Shotgun data and field value.
             field_value = text_data
             sg_data = sg_data["ref"]["value"]
 
             # For our example, as expected, the field value is now 'Bunny' and the Shotgun data is now:
-            #     {'id':             1230,
-            #      'type':           'Asset',
-            #      'code':           'Bunny',
-            #      'description':    '...',
-            #      'image':          '/thumbnail/Asset/1230?567',
-            #      'sg_status_list': 'fin'}
+            # {
+            #     'id': 1230,
+            #     'type': 'Asset',
+            #     'code': 'Bunny',
+            #     'description': '...',
+            #     'image': '/thumbnail/Asset/1230?567',
+            #     'sg_status_list': 'fin'
+            # }
 
-    elif isinstance(field_data, dict) and "value" in field_data:
+    else:
         # We have a ShotgunModel item.
 
         # Just extract the current field value and keep the Shotgun data as is.
         field_value = field_data["value"]
-
-    else:
-        raise TankError("Unknown item '%s' model type!" % text_data)
 
     return (sg_data, field_value)

--- a/python/tk_multi_loader/model_item_data.py
+++ b/python/tk_multi_loader/model_item_data.py
@@ -19,6 +19,11 @@ def get_item_data(item):
     """
     Extracts and standardizes the Shotgun data and field value from an item.
 
+    Since the overall Loader code expects ShotgunModel items with specific SG_DATA_ROLE
+    and SG_ASSOCIATED_FIELD_ROLE data formats, the main goal of this function is to build
+    such formats when the passed in item belongs to ShotgunHierarchyModel with
+    a very different SG_DATA_ROLE data format and no SG_ASSOCIATED_FIELD_ROLE data.
+
     :param item: Selected item or model index.
     :return: Standardized `(Shotgun data, field value)` extracted from the item data.
     """
@@ -27,6 +32,7 @@ def get_item_data(item):
     text_data = shotgun_model.get_sanitized_data(item, QtCore.Qt.DisplayRole)
 
     # Get the item data for user role SG_DATA_ROLE.
+    #
     # For an item in the ShotgunModel tree structure:
     # - for an intermediate item, this data is None.
     # - for a leaf item, this data is a dictionary with keys:
@@ -35,32 +41,98 @@ def get_item_data(item):
     #       plus usually "code", "project" and "sg_sequence" for shots,
     #       plus usually "content", "entity" and "project" for tasks,
     #       plus "description", "image" and "sg_status_list".
+    #
+    # Example for a ShotgunModel asset leaf item:
+    #     {'id':             1230,
+    #      'type':           'Asset',
+    #      'code':           'Bunny',
+    #      'project':        {'id': 70, 'name': 'Demo: Animation', 'type': 'Project'},
+    #      'sg_asset_type':  'Character',
+    #      'description':    '...',
+    #      'image':          'https://...',
+    #      'sg_status_list': 'fin'}
+    #
+    # Example for a ShotgunModel shot leaf item:
+    #     {'id':             862,
+    #      'type':           'Shot',
+    #      'code':           'bunny_010_0010',
+    #      'project':        {'id': 70, 'name': 'Demo: Animation', 'type': 'Project'},
+    #      'sg_sequence':    {'id': 23, 'name': 'bunny_010', 'type': 'Sequence'},
+    #      'description':    '...',
+    #      'image':          'https://s...',
+    #      'sg_status_list': 'fin'}
+    #
     # For an item in the ShotgunHierarchyModel tree structure,
     # this data is a dictionary with these keys among others:
     # - "has_children" with a boolean value,
     # - "ref" which value is a dictionary with keys:
     #       "kind" and "value"
+    #
+    # Example for a ShotgunHierarchyModel intermediate item (without any extra entity fields requested):
+    #     {'has_children':    True,
+    #      'label':           'Character',
+    #      'path':            '/Project/70/Asset/sg_asset_type/Character',
+    #      'ref':             {'kind': 'list', 'value': 'Character'},
+    #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character',
+    #                                                         'preset_name': 'NAV_ENTRIES',
+    #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
+    #                          'type': 'PublishedFile'}}
+    #
+    # Example for a ShotgunHierarchyModel leaf item (with the extra entity fields requested):
+    #     {'has_children':    False,
+    #      'label':           'Bunny',
+    #      'path':            '/Project/70/Asset/sg_asset_type/Character/id/1230',
+    #      'ref':             {'kind': 'entity', 'value': {'id':             1230,
+    #                                                      'type':           'Asset',
+    #                                                      'code':           'Bunny',
+    #                                                      'description':    '...',
+    #                                                      'image':          '/thumbnail/Asset/1230?567',
+    #                                                      'sg_status_list': 'fin'}},
+    #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character/id/1230',
+    #                                                         'preset_name': 'NAV_ENTRIES',
+    #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
+    #                          'type': 'PublishedFile'}}
+    #
     sg_data = shotgun_model.get_sg_data(item)
 
     # Get the item data for user role SG_ASSOCIATED_FIELD_ROLE.
+    #
     # For an item in the ShotgunModel tree structure,
     # this data is a dictionary with keys "name" and "value":
     # - for an entity link, this value is a dictionary with keys:
     #       "id", "name" and "type"
     # - othewise, this value is the text data.
     # - "value" can also be a list of such values.
-    # For an item in the ShotgunHierarchyModel tree structure,
-    # this data is None.
+    #
+    # Examples for a ShotgunModel intermediate item:
+    #     {'name': 'sg_asset_type', 'value': 'Character'}
+    #     {'name': 'sg_sequence', 'value': {'id': 23, 'name': 'bunny_010', 'type': 'Sequence'}}
+    #
+    # Examples for a ShotgunModel leaf item:
+    #     {'name': 'code', 'value': 'Bunny'}
+    #     {'name': 'code', 'value': 'bunny_010_0010'}
+    #
+    # For an item in the ShotgunHierarchyModel tree structure, this data is None.
+    #
     field_data = shotgun_model.get_sanitized_data(item, shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-
-    error_msg = "Unknown item '%s' model type!" % text_data
 
     if field_data is None and \
        isinstance(sg_data, dict) and "has_children" in sg_data and "ref" in sg_data and \
        isinstance(sg_data["ref"], dict) and "value" in sg_data["ref"]:
         # We have a ShotgunHierarchyModel item.
+
         if sg_data["has_children"]:
             # We have an intermediate item.
+            # For example:
+            #     {'has_children':    True,
+            #      'label':           'Character',
+            #      'path':            '/Project/70/Asset/sg_asset_type/Character',
+            #      'ref':             {'kind': 'list', 'value': 'Character'},
+            #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character',
+            #                                                         'preset_name': 'NAV_ENTRIES',
+            #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
+            #                          'type': 'PublishedFile'}}
+
             # Standardize its Shotgun data and field value.
             ref_value = sg_data["ref"]["value"]
             if isinstance(ref_value, dict):
@@ -72,17 +144,45 @@ def get_item_data(item):
             else:
                 field_value = text_data
             sg_data = None
+
+            # For our example, as expected, the field value is now 'Character' and there is no more Shotgun data.
+
         else:
             # We have a leaf item.
+            # For example:
+            #     {'has_children':    False,
+            #      'label':           'Bunny',
+            #      'path':            '/Project/70/Asset/sg_asset_type/Character/id/1230',
+            #      'ref':             {'kind': 'entity', 'value': {'id':             1230,
+            #                                                      'type':           'Asset',
+            #                                                      'code':           'Bunny',
+            #                                                      'description':    '...',
+            #                                                      'image':          '/thumbnail/Asset/1230?567',
+            #                                                      'sg_status_list': 'fin'}},
+            #      'target_entities': {'additional_filter_presets': [{'path':        '/Project/70/Asset/sg_asset_type/Character/id/1230',
+            #                                                         'preset_name': 'NAV_ENTRIES',
+            #                                                         'seed':        {'field': 'entity', 'type': 'PublishedFile'}}],
+            #                          'type': 'PublishedFile'}}
+
             # Standardize its Shotgun data and field value.
             field_value = text_data
             sg_data = sg_data["ref"]["value"]
 
+            # For our example, as expected, the field value is now 'Bunny' and the Shotgun data is now:
+            #     {'id':             1230,
+            #      'type':           'Asset',
+            #      'code':           'Bunny',
+            #      'description':    '...',
+            #      'image':          '/thumbnail/Asset/1230?567',
+            #      'sg_status_list': 'fin'}
+
     elif isinstance(field_data, dict) and "value" in field_data:
         # We have a ShotgunModel item.
+
+        # Just extract the current field value and keep the Shotgun data as is.
         field_value = field_data["value"]
 
     else:
-        raise TankError(error_msg)
+        raise TankError("Unknown item '%s' model type!" % text_data)
 
     return (sg_data, field_value)

--- a/python/tk_multi_loader/model_item_data.py
+++ b/python/tk_multi_loader/model_item_data.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+from sgtk import TankError
+from sgtk.platform.qt import QtCore
+
+shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
+
+
+def get_item_data(item):
+    """
+    Extracts and standardizes the Shotgun data and field value from an item.
+
+    :param item: Selected item or model index.
+    :return: Standardized `(Shotgun data, field value)` extracted from the item data.
+    """
+
+    # Get the item data to be rendered in the form of text.
+    text_data = shotgun_model.get_sanitized_data(item, QtCore.Qt.DisplayRole)
+
+    # Get the item data for user role SG_DATA_ROLE.
+    # For an item in the ShotgunModel tree structure:
+    # - for an intermediate item, this data is None.
+    # - for a leaf item, this data is a dictionary with keys:
+    #       "id" and "type",
+    #       plus usually "code", "project" and "sg_asset_type" for assets,
+    #       plus usually "code", "project" and "sg_sequence" for shots,
+    #       plus usually "content", "entity" and "project" for tasks,
+    #       plus "description", "image" and "sg_status_list".
+    # For an item in the ShotgunHierarchyModel tree structure,
+    # this data is a dictionary with these keys among others:
+    # - "has_children" with a boolean value,
+    # - "ref" which value is a dictionary with keys:
+    #       "kind" and "value"
+    sg_data = shotgun_model.get_sg_data(item)
+
+    # Get the item data for user role SG_ASSOCIATED_FIELD_ROLE.
+    # For an item in the ShotgunModel tree structure,
+    # this data is a dictionary with keys "name" and "value":
+    # - for an entity link, this value is a dictionary with keys:
+    #       "id", "name" and "type"
+    # - othewise, this value is the text data.
+    # - "value" can also be a list of such values.
+    # For an item in the ShotgunHierarchyModel tree structure,
+    # this data is None.
+    field_data = shotgun_model.get_sanitized_data(item, shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
+
+    error_msg = "Unknown item '%s' model type!" % text_data
+
+    if field_data is None and \
+       isinstance(sg_data, dict) and "has_children" in sg_data and "ref" in sg_data and \
+       isinstance(sg_data["ref"], dict) and "value" in sg_data["ref"]:
+        # We have a ShotgunHierarchyModel item.
+        if sg_data["has_children"]:
+            # We have an intermediate item.
+            # Standardize its Shotgun data and field value.
+            ref_value = sg_data["ref"]["value"]
+            if isinstance(ref_value, dict):
+                if "name" in ref_value:
+                    field_value = ref_value
+                else:
+                    field_value = ref_value.copy()
+                    field_value["name"] = text_data
+            else:
+                field_value = text_data
+            sg_data = None
+        else:
+            # We have a leaf item.
+            # Standardize its Shotgun data and field value.
+            field_value = text_data
+            sg_data = sg_data["ref"]["value"]
+
+    elif isinstance(field_data, dict) and "value" in field_data:
+        # We have a ShotgunModel item.
+        field_value = field_data["value"]
+
+    else:
+        raise TankError(error_msg)
+
+    return (sg_data, field_value)

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -303,9 +303,10 @@ class SgLatestPublishModel(ShotgunModel):
             # Extract the Shotgun data and field value from the tree view item.
             (tree_view_sg_data, field_value) = model_item_data.get_item_data(tree_view_item)
 
-            # Rebuild tree view item field data.
-            # Since we do not care about the "name" value, arbitrarily use "data".
-            tree_view_field_data = {"name": "data", "value": field_value}
+            # Rebuild field data with the field value.
+            # Since this data will be consumed by SgPublishListDelegate._format_folder() and
+            # SgPublishThumbDelegate._format_folder(), key "value" is the only key needed.
+            tree_view_field_data = {"value": field_value}
 
             # copy across the std fields SG_ASSOCIATED_FIELD_ROLE and SG_DATA_ROLE
             item.setData(tree_view_sg_data, SgLatestPublishModel.SG_DATA_ROLE)


### PR DESCRIPTION
Handle a new configuration setting option that adds the capability to define left hand side tabs driven by the new Shotgun hierarchy model.
