### PR TITLE
#40162 Upgraded to use open sans

### DIFF
--- a/style.qss
+++ b/style.qss
@@ -1,0 +1,18 @@
+/*
+Copyright (c) 2015 Shotgun Software Inc.
+ 
+CONFIDENTIAL AND PROPRIETARY
+ 
+This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+Source Code License included in this distribution package. See LICENSE.
+By accessing, using, copying or modifying this work you indicate your 
+agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+not expressly granted therein are reserved by Shotgun Software Inc.
+*/
+
+/* Use open sans font across the app if core supports it */
+QWidget {
+    font-family: "Open Sans";
+    font-style: "Regular";
+}
+


### PR DESCRIPTION
Now uses open sans.

Before:
![image](https://cloud.githubusercontent.com/assets/337710/21753714/86745502-d5ea-11e6-8fbd-5351bb1b9f23.png)


Now:

![image](https://cloud.githubusercontent.com/assets/337710/21753708/6e5b8d8c-d5ea-11e6-9098-b650f8a483a5.png)
