### PR TITLE
#41778 Loader should ignore publishes with no status

### DIFF
--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -73,6 +73,15 @@ class SgPublishHistoryModel(ShotgunModel):
                     [publish_type_field, "is", sg_data[publish_type_field] ],
                   ]
 
+        # ignore publishes without a status. with zero config, it is very easy
+        # to publish the same path multiple times. we warn in the publisher that
+        # previous publishes of the same path will not be visible in the loader
+        # to avoid confusion. when publishing a path that has already been
+        # published, the publish app will clear the status of previous
+        # publishes. this additional filter brings means the loader will only
+        # show the last publish of a particular file.
+        filters.append(["sg_status_list", "is_not", None])
+
         # add external filters from config
         app = sgtk.platform.current_bundle()
         pub_filters = app.get_setting("publish_filters", [])


### PR DESCRIPTION
With zero config, it is easy to publish the same file multiple times. If the file does not have an obvious version number baked in, then you can end up with multiple `PublishedFile` entries with the same path and version number. This causes the loader to display multiple entries in the publish history list.

The publish 2.0 plugins will clear the status of previous publishes of the same path. This change to the loader completes the circle and prevents those publishes from showing in the loader UI, hopefully making things clearer.

The biggest question is whether this is Ok as-is or if we should add a setting for backward compatibility with tk classic workflows. My initial thought was that nothing out there currently (that we know of) is clearing the status of publishes. So perhaps this is ok without a setting?