### PR TITLE
For #41930, loader hierarchy adjustments

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1354,7 +1354,7 @@ class AppDialog(QtGui.QWidget):
 
     def _hierarchy_refreshed(self):
         """
-        Signal triggered when the hierarchy model has been refreshed. This allows to show all the
+        Slot triggered when the hierarchy model has been refreshed. This allows to show all the
         folder items in the right-hand side for the current selection.
         """
         selected_item = self._get_selected_entity()

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1354,6 +1354,16 @@ class AppDialog(QtGui.QWidget):
 
     def _hierarchy_refreshed(self):
         """
+        Signal triggered when someone changes the selection in a treeview.
+        """
+
+        selected_item = self._get_selected_entity()
+
+        # tell publish UI to update itself
+        self._load_publishes_for_entity_item(selected_item)
+
+    def _hierarchy_refreshed(self):
+        """
         Slot triggered when the hierarchy model has been refreshed. This allows to show all the
         folder items in the right-hand side for the current selection.
         """

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1257,8 +1257,8 @@ class AppDialog(QtGui.QWidget):
                 )
                 # When getting back the model items that were loaded, we will need the view and proxy model
                 # to expand the item.
-                model.deep_load_completed.connect(
-                    lambda item, view=view, proxy_model=proxy_model: self._deep_load_completed(
+                model.async_load_completed.connect(
+                    lambda item, view=view, proxy_model=proxy_model: self._async_load_completed(
                         item, view, proxy_model
                     )
                 )
@@ -1462,9 +1462,9 @@ class AppDialog(QtGui.QWidget):
         """
         source_model = proxy_model.sourceModel()
         # Asynchronously retrieve the nodes that lead to the item we picked.
-        source_model.async_deep_load(incremental_paths)
+        source_model.async_load_paths(incremental_paths)
 
-    def _deep_load_completed(self, item, view, proxy_model):
+    def _async_load_completed(self, item, view, proxy_model):
         """
         Called when the last node from the deep load is loaded.
         """

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1428,7 +1428,7 @@ class AppDialog(QtGui.QWidget):
 
     def _hierarchy_refreshed(self):
         """
-        Signal triggered when someone changes the selection in a treeview.
+        Slot triggered when the hierarchy model has been refreshed. This allows to show all the
         """
 
         selected_item = self._get_selected_entity()

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1207,7 +1207,8 @@ class AppDialog(QtGui.QWidget):
 
             if not type_hierarchy:
 
-                # FIXME: We should probably remove all of this block in favor of something like
+                # FIXME: We should probably remove all of this block in favor of something like. Doesn't quite
+                # work at the moment so I'm leaving it as a suggestion to a future reader.
                 # search = SearchWidget(tab)
                 # search.setToolTip("Use the <i>search</i> field to narrow down the items displayed in the tree above.")
                 # search_layout.addWidget(search)

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -785,7 +785,7 @@ class AppDialog(QtGui.QWidget):
 
     def _on_home_clicked(self):
         """
-        User clicks the home button. The code will always try to match 
+        User clicks the home button.
         """
         # first, try to find the "home" item by looking at the current app context.
         found_preset = None
@@ -822,7 +822,7 @@ class AppDialog(QtGui.QWidget):
             # We're about to programmatically set the tab and then the item, so inform
             # the tab switcher that this is a combo operation and shouldn't be tracked
             # by the history.
-            self._select_tab(found_hierarchy_preset, combo_operation_mode=True)
+            self._select_tab(found_hierarchy_preset, track_in_history=False)
             # Kick off an async load of an entity, which in the context of the loader
             # is always meant to switch select that item.
             preset.model.async_item_from_entity(ctx.entity)
@@ -1029,7 +1029,14 @@ class AppDialog(QtGui.QWidget):
 
         return selected_item
 
-    def _select_tab(self, tab_caption, combo_operation_mode):
+    def _select_tab(self, tab_caption, track_in_history):
+        """
+        Programmatically selects a tab based on the requested caption.
+
+        :param str tab_caption: Name of the tab to bring forward.
+        :param track_in_history: If ``True``, the tab switch will be registered in the
+            history.
+        """
         if tab_caption != self._current_entity_preset:
             for idx in range(self.ui.entity_preset_tabs.count()):
                 tab_name = self.ui.entity_preset_tabs.tabText(idx)
@@ -1044,7 +1051,7 @@ class AppDialog(QtGui.QWidget):
                     finally:
                         self._disable_tab_event_handler = False
                     # now run the logic for the switching
-                    self._switch_profile_tab(idx, combo_operation_mode)
+                    self._switch_profile_tab(idx, track_in_history)
 
     def _select_item_in_entity_tree(self, tab_caption, item):
         """
@@ -1063,7 +1070,7 @@ class AppDialog(QtGui.QWidget):
         # 3) we are on the wrong tab and need to switch but there is no item to select
 
         # Phase 1 - first check if we need to switch tabs
-        self._select_tab(tab_caption, item is not None)
+        self._select_tab(tab_caption, item is None)
 
         # Phase 2 - Now select and zoom onto the item
         view = self._entity_presets[self._current_entity_preset].view
@@ -1560,16 +1567,15 @@ class AppDialog(QtGui.QWidget):
         """
         if not self._disable_tab_event_handler:
             curr_tab_index = self.ui.entity_preset_tabs.currentIndex()
-            self._switch_profile_tab(curr_tab_index, False)
+            self._switch_profile_tab(curr_tab_index, track_in_history=True)
 
-    def _switch_profile_tab(self, new_index, combo_operation_mode):
+    def _switch_profile_tab(self, new_index, track_in_history):
         """
         Switches to use the specified profile tab.
 
         :param new_index: tab index to switch to
-        :param combo_operation_mode: hint to this method that if set to True,
-                                     this tab switch is part of a sequence of
-                                     operations and not stand alone.
+        :param track_in_history: Hint to this method that the actions should be tracked in the
+            history.
         """
         # qt returns unicode/qstring here so force to str
         curr_tab_name = shotgun_model.sanitize_qt(self.ui.entity_preset_tabs.tabText(new_index))

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -825,7 +825,7 @@ class AppDialog(QtGui.QWidget):
             self._select_tab(found_hierarchy_preset, combo_operation_mode=True)
             # Kick off an async load of an entity, which in the context of the loader
             # is always meant to switch select that item.
-            preset.model.async_load_entity(ctx.entity)
+            preset.model.async_item_from_entity(ctx.entity)
             return
         else:
             if found_preset is None:
@@ -1263,8 +1263,8 @@ class AppDialog(QtGui.QWidget):
                 )
                 # When getting back the model items that were loaded, we will need the view and proxy model
                 # to expand the item.
-                model.async_load_completed.connect(
-                    lambda item, view=view, proxy_model=proxy_model: self._async_load_completed(
+                model.async_item_retrieval_completed.connect(
+                    lambda item, view=view, proxy_model=proxy_model: self._async_item_retrieval_completed(
                         item, view, proxy_model
                     )
                 )
@@ -1468,9 +1468,9 @@ class AppDialog(QtGui.QWidget):
         """
         source_model = proxy_model.sourceModel()
         # Asynchronously retrieve the nodes that lead to the item we picked.
-        source_model.async_load_paths(incremental_paths)
+        source_model.async_item_from_paths(incremental_paths)
 
-    def _async_load_completed(self, item, view, proxy_model):
+    def _async_item_retrieval_completed(self, item, view, proxy_model):
         """
         Called when the last node from the deep load is loaded.
         """

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1354,9 +1354,9 @@ class AppDialog(QtGui.QWidget):
 
     def _hierarchy_refreshed(self):
         """
-        Signal triggered when someone changes the selection in a treeview.
+        Signal triggered when the hierarchy model has been refreshed. This allows to show all the
+        folder items in the right-hand side for the current selection.
         """
-
         selected_item = self._get_selected_entity()
 
         # tell publish UI to update itself

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -36,6 +36,7 @@ shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "sho
 settings = sgtk.platform.import_framework("tk-framework-shotgunutils", "settings")
 help_screen = sgtk.platform.import_framework("tk-framework-qtwidgets", "help_screen")
 overlay_widget = sgtk.platform.import_framework("tk-framework-qtwidgets", "overlay_widget")
+shotgun_search_widget = sgtk.platform.import_framework("tk-framework-qtwidgets", "shotgun_search_widget")
 task_manager = sgtk.platform.import_framework("tk-framework-shotgunutils", "task_manager")
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 
@@ -1229,6 +1230,22 @@ class AppDialog(QtGui.QWidget):
                 # Keep a handle to all the new Qt objects, otherwise the GC may not work.
                 self._dynamic_widgets.extend([search_layout, search, clear_search, icon])
 
+            else:
+
+                search = shotgun_search_widget.HierarchicalSearchWidget(tab)
+
+                search.set_search_root(sgtk.platform.current_engine().context.project)
+                search.node_activated.connect(
+                    lambda entity_type, entity_id, name, path, incremental_paths,
+                    view=view, proxy_model=proxy_model: self._node_activated(
+                        entity_type, entity_id, name, path, incremental_paths,
+                        view, proxy_model
+                    )
+                )
+                search.set_bg_task_manager(self._task_manager)
+
+                layout.addWidget(search)
+
             # We need to handle tool tip display ourselves for action context menus.
             def action_hovered(action):
                 tip = action.toolTip()
@@ -1381,6 +1398,12 @@ class AppDialog(QtGui.QWidget):
 
         # tell publish UI to update itself
         self._load_publishes_for_entity_item(selected_item)
+
+    def _node_activated(self, entity_type, entity_id, name, label_path, incremental_paths, view, proxy_model):
+        print entity_type, entity_id, name
+        print label_path
+        print incremental_paths
+        print view, proxy_model
 
     def _setup_query_model(self, app, setting_dict):
         """

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -22,21 +22,15 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
     hierarchy tree view tabs on the left-hand-side of the dialog.
     """
 
-    def __init__(self, parent, path=None, bg_task_manager=None):
+    def __init__(self, parent, root_entity=None, bg_task_manager=None):
         """
         Initializes a Shotgun Hierarchy model instance and loads a hierarchy
         that leads to entities that are linked via the ``PublishedFile.entity`` field.
 
         :param parent: The model parent.
         :type parent: :class:`~PySide.QtGui.QObject`
-        :param str path: The path to the root of the hierarchy to display.
-                         This corresponds to the ``path`` argument of the
-                         :meth:`~shotgun-api3:shotgun_api3.Shotgun.nav_expand()` API method.
-                         For example, ``/Project/65`` would correspond to a project on your
-                         Shotgun site with id ``65``. By default, this value is ``None``
-                         and the project from the current project will be used. If no project
-                         can be determined, the path will default to ``/`` and
-                         all projects will be represented as top-level items in the model.
+        :param dict root_entity: The entity which will act as the root of the hierarchy to display.
+                                 By default, this value is ``None``, which will default to the entire site.
         :param bg_task_manager: Background task manager to use for any asynchronous work.
                                 If this is ``None`` a task manager will be created as needed.
         :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
@@ -49,7 +43,7 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
         }
 
         # Load a hierarchy that leads to entities that are linked via the "PublishedFile.entity" field.
-        self.load_data("PublishedFile.entity", path=path, entity_fields=entity_fields)
+        self.load_data("PublishedFile.entity", root=root_entity, entity_fields=entity_fields)
 
     def reload_data(self):
         """
@@ -59,6 +53,6 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
 
         self.load_data(
             self._seed_entity_field,
-            path=self._path,
+            entity=self._root_entity,
             entity_fields=self._entity_fields
         )

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -44,13 +44,9 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
 
         SimpleShotgunHierarchyModel.__init__(self, parent, bg_task_manager=bg_task_manager)
 
-        # We need to provide a dictionary that identifies what additional fields to include
-        # for the loaded hierarchy leaf entities in addition to "id" and "type".
-        # When they are available for an entity, these fields will be used to add info in the detail panel.
-        # TODO: Our entity type list for entities with publishes should be retrieved from somewhere.
-        entity_fields = {}
-        for entity_type in ["Asset", "Shot"]:
-            entity_fields[entity_type] = ["code", "description", "image", "sg_status_list"]
+        entity_fields = {
+            "__all__": ["code", "description", "image", "sg_status_list"]
+        }
 
         # Load a hierarchy that leads to entities that are linked via the "PublishedFile.entity" field.
         self.load_data("PublishedFile.entity", path=path, entity_fields=entity_fields)


### PR DESCRIPTION
This adds a series of features.

- Pressing Home folder will take you to the current entity in the hierarchy view.
- Configuration now takes an entity string instead of a path to the root of the hierarchy view.
- Entity types are not hardcoded anymore and rely on `__all__`.
- Seach completer widget has been hooked up with the hierarchy view.