### PR TITLE
SMOK-29361 | tk-flame_action improved

### DIFF
--- a/hooks/tk-flame_actions.py
+++ b/hooks/tk-flame_actions.py
@@ -415,6 +415,18 @@ class FlameActions(HookBaseClass):
         return self.configuration.get("write_file_media_path_pattern")
 
     @property
+    def media_path_root(self):
+        """
+        This path helps to setup the write_file_node by specifying where to write the medias.
+
+        This is defined by the "write_file_media_path_root" entry of the configuration dictionary
+
+        :return: Media path root
+        :type: str
+        """
+        return self.configuration.get("write_file_media_path_root")
+
+    @property
     def clip_path_pattern(self):
         """
         This pattern helps to setup the write_file_node by specifying where to write the clips.
@@ -638,6 +650,7 @@ class FlameActions(HookBaseClass):
             media_path_set = True
 
         if not media_path_set and self.media_path_pattern:
+            write_file_info["media_path"] = self.media_path_root
             write_file_info["media_path_pattern"] = self.media_path_pattern.format(**fields)
 
         if "version_padding" not in write_file_info and self.version_padding:

--- a/hooks/tk-flame_actions.py
+++ b/hooks/tk-flame_actions.py
@@ -30,7 +30,7 @@ HookBaseClass = sgtk.get_hook_baseclass()
 ##############################################################################################################
 # Constants to be used with Flame
 
-BATCH_ACTION = "load_setup"
+SETUP_ACTION = "load_setup"
 CLIP_ACTION = "load_clip"
 SHOT_LOAD_ACTION = "load_batch"
 SHOT_CREATE_ACTION = "create_batch"
@@ -91,8 +91,8 @@ class FlameActions(HookBaseClass):
             app.log_warning("Unable to import the Flame Python API")
             return action_instances
 
-        if BATCH_ACTION in actions:
-            action_instances.append({"name": BATCH_ACTION,
+        if SETUP_ACTION in actions:
+            action_instances.append({"name": SETUP_ACTION,
                                      "params": None,
                                      "caption": "Load and Append Batch Setup",
                                      "description": "Load and append a batch setup file to the current Batch Group."})
@@ -167,7 +167,7 @@ class FlameActions(HookBaseClass):
             if name == CLIP_ACTION:
                 self._import_clip(sg_publish_data)
 
-            elif name == BATCH_ACTION:
+            elif name == SETUP_ACTION:
                 self._import_batch_file(sg_publish_data)
 
             elif name == SHOT_CREATE_ACTION:
@@ -327,7 +327,7 @@ class FlameActions(HookBaseClass):
         """
 
         return [entry[0] for entry in self.parent.get_setting("action_mappings", {}).items() if
-                BATCH_ACTION in entry[1]]
+                SETUP_ACTION in entry[1]]
 
     @property
     def import_location(self):
@@ -350,9 +350,6 @@ class FlameActions(HookBaseClass):
         :return: Hint about using a linking a Write File node
         :rtype: bool
         """
-
-        if sgtk.platform.current_engine().is_version_less_than("2018.3"):
-            return False
 
         return True
 
@@ -899,10 +896,10 @@ class FlameActions(HookBaseClass):
         frame_len = int(match.group(2)[1:-1])
 
         # Lets retrieve all the files that's in the folder of the file to match
-        if not os.path.exists(folder):
-            raise FlameActionError("Folder not found in disk: '%s'" % folder)
-
-        files = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
+        try:
+            files = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
+        except OSError, e:
+            raise FlameActionError("Unable to guess the frame range for '%s'" % path)
 
         for f in files:
             # It doesn't match our pattern

--- a/hooks/tk-flame_actions.py
+++ b/hooks/tk-flame_actions.py
@@ -1001,8 +1001,8 @@ class FlameActions(HookBaseClass):
 
         folder, file_name = ntpath.split(media_path)
 
-        # Try to check if the path is sa sequence
-        match = re.match(r"(.+\.)((?:\[\d+-\d+\])|(?:\d+))(\..+)", file_name)
+        # Try to check if the path is a sequence
+        match = re.match(r"(.*)(\[\d+-\d+\])(.+)", file_name)
 
         if not match:
             # The path is not a sequence

--- a/hooks/tk-flame_actions.py
+++ b/hooks/tk-flame_actions.py
@@ -8,34 +8,48 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+
 """
 Hook that loads defines all the available actions, broken down by publish type.
 """
+import collections
+import ntpath
+import os
+import re
+
 import sgtk
 from sgtk import TankError
-import flame
 
-import os
+# First flame version with the Python API is 2018.2
+if sgtk.platform.current_engine().is_version_less_than("2018.2"):
+    flame = None
+else:
+    try:
+        # The python API is available
+        import flame
+
+    except ImportError:
+        # Unable to load the python API
+        flame = None
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
 ##############################################################################################################
 # Constants to be used with Flame
 
-# Defines the Schematic Reel we will use
-# Ideally this wouldn't be hardcoded, but there exists no way currently
-# to import clips without specifying a schematic reel
-SCHEMATIC_REEL = "Schematic Reel 1"
+BATCH_ACTION = "load_setup"
+CLIP_ACTION = "load_clip"
+SHOT_LOAD_ACTION = "load_batch"
+SHOT_CREATE_ACTION = "create_batch"
 
 
-class FlameActionError(Exception):
+class FlameActionsError(Exception):
     pass
 
 
 class FlameActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
-
     def generate_actions(self, sg_publish_data, actions, ui_area):
         """
         Returns a list of action instances for a particular publish.
@@ -80,23 +94,34 @@ class FlameActions(HookBaseClass):
 
         action_instances = []
 
-        if "load_setup" in actions:
-            action_instances.append({"name": "load_setup",
+        if not flame:
+            app.log_warning("Unable to import the Flame Python API")
+            return action_instances
+
+        if BATCH_ACTION in actions:
+            action_instances.append({"name": BATCH_ACTION,
                                      "params": None,
                                      "caption": "Load Batch Group",
                                      "description": "This will load a batch setup"})
 
-        if "load_clip" in actions:
-            action_instances.append({"name": "load_clip",
+        if CLIP_ACTION in actions:
+            action_instances.append({"name": CLIP_ACTION,
                                      "params": None,
                                      "caption": "Import clip",
                                      "description": "This will import the clip to the current Batch Group."})
 
-        if "load_batch" in actions:
-            action_instances.append({"name": "load_batch",
+        if SHOT_CREATE_ACTION in actions:
+            action_instances.append({"name": SHOT_CREATE_ACTION,
                                      "params": None,
                                      "caption": "Create a Batch Group",
                                      "description": "This will create a Batch Group using the media found inside the "
+                                                    "folder"})
+
+        if SHOT_LOAD_ACTION in actions:
+            action_instances.append({"name": SHOT_LOAD_ACTION,
+                                     "params": None,
+                                     "caption": "Load a Batch Group",
+                                     "description": "This will Load a Batch Group using the setup found inside the "
                                                     "folder"})
 
         return action_instances
@@ -142,103 +167,127 @@ class FlameActions(HookBaseClass):
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         :returns: No return value expected.
         """
+
         app = self.parent
         app.log_debug("Execute action called for action %s. "
                       "Parameters: %s. Publish Data: %s" % (name, params, sg_publish_data))
 
         try:
-            if name == "load_clip":
+            if name == CLIP_ACTION:
                 self._import_clip(sg_publish_data)
 
-            elif name == "load_setup":
+            elif name == BATCH_ACTION:
                 self._import_batch_file(sg_publish_data)
 
-            elif name == "load_batch":
-                self._import_batch_group_from_shot(sg_publish_data)
+            elif name == SHOT_CREATE_ACTION:
+                self._add_batch_group_from_shot(sg_publish_data, True)
+
+            elif name == SHOT_LOAD_ACTION:
+                self._add_batch_group_from_shot(sg_publish_data, False)
 
             else:
-                raise FlameActionError("Unknown action name")
-        except FlameActionError as error:
-            self.parent.log_warning("Flame Action Error: {}".format(str(error)))
+                raise FlameActionsError("Unknown action name")
+        except FlameActionsError as error:
+            # A FlameActionError reaching here mean that something major have stopped the current action
+            app.log_error(error)
 
     ##############################################################################################################
     # methods called by the menu options in the loader
 
     def _import_batch_file(self, sg_publish_data):
         """
-        Imports a Batch Group from Shotgun into Flame.
+        Imports a Batch setup into Flame.
+
+        This function import the Batch setup into the current Batch Group.
         
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         :type sg_publish_data: dict
         """
 
-        batch_path = self.get_publish_path(sg_publish_data)
+        app = self.parent
+        app.log_debug("Importing batch file using '%s'" % sg_publish_data)
 
-        # Only load the batch if it exists
-        if batch_path and os.path.exists(batch_path):
+        setup_path = self.get_publish_path(sg_publish_data)
+
+        # Directly load the setup if exists
+        if setup_path and os.path.exists(setup_path):
             flame.batch.go_to()
-            flame.batch.load_setup(batch_path)
-            flame.batch.organize()
+
+            if not flame.batch.load_setup(setup_path):
+                raise FlameActionsError("Unable to load a Batch Setup")
+
         else:
-            raise FlameActionError("File not found on disk - '%s'" % batch_path)
+            raise FlameActionsError("File not found on disk - '%s'" % setup_path)
 
     def _import_clip(self, sg_publish_data):
         """
-        Imports a clip to the current Batch Group.
+        Imports a clip into Flame.
+
+        This function import the clip into self.import_location (Default: Schematic Reel 1) in the current Batch Group.
 
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
         :type sg_publish_data: dict
         """
+
+        app = self.parent
+        app.log_debug("Importing clip using '%s'" % sg_publish_data)
 
         clip_path = self.get_publish_path(sg_publish_data)
 
-        # Only load the clip if it exists
-        if clip_path and os.path.exists(clip_path):
+        # Load directly if the clip exists
+        if clip_path and self._exists(clip_path):
+            # The clip path exists so we can import it into Flame!
             flame.batch.go_to()
-            flame.batch.import_clip(clip_path, SCHEMATIC_REEL)
+
+            if not flame.batch.import_clip(clip_path, self.import_location):
+                raise FlameActionsError("Unable to import '%s'" % clip_path)
+
             flame.batch.organize()
-        elif '%' in clip_path:
-            try:
-                # Special case parsing for frames, attempts to expand
-                temp_filters = [["id", "is", sg_publish_data["version"]["id"]]]
-                temp_fields = ["frame_range"]
-                temp_type = "Version"
 
-                temp_info = self.parent.shotgun.find_one(
-                    temp_type, filters=temp_filters, fields=temp_fields
-                )
+        # The clip name doesn't directly exists, but it might contain a pattern that we need to resolve.
+        elif clip_path and '%' in clip_path:
+            new_path = self._handle_frame_range(clip_path)["path"]
 
-                # Unfortunately, we can't do simple formatting here as %<num>d
-                # old style Python formatting does not support getting a frame
-                # range. Thus we need to parse it ourselves
-                new_path = self._handle_frame_range(
-                    clip_path, temp_info["frame_range"]
-                )
-
-                if new_path and len(new_path) != 0:
-                    clip_path = new_path
-
+            # The sequence exists on disk
+            if self._exists(new_path):
                 flame.batch.go_to()
-                flame.batch.import_clip(clip_path, SCHEMATIC_REEL)
-                flame.batch.organize()
-            except Exception:
-                raise FlameActionError("File not found on disk - '%s'" % clip_path)
-        else:
-            raise FlameActionError("File not found on disk - '%s'" % clip_path)
 
-    def _import_batch_group_from_shot(self, sg_publish_data):
+                if not flame.batch.import_clip(new_path, self.import_location):
+                    raise FlameActionsError("Unable to import '%s'" % clip_path)
+
+                flame.batch.organize()
+
+            # The sequence doesn't exist on disk
+            else:
+                raise FlameActionsError("Sequence not found on disk - '%s'" % new_path)
+
+        # Clip path doesn't exists and doesn't contain any pattern
+        else:
+            raise FlameActionsError("File not found on disk - '%s'" % clip_path)
+
+    def _add_batch_group_from_shot(self, sg_publish_data, build_new):
         """
-        Imports a Batch Group from Shotgun Shot into Flame.
+        Add a batch group into Flame.
+
+        If build_new is True, it loads last version of every clip present in the Shot, otherwise it create the batch
+        group using the latest version of the batch file present in the Shot ( Do nothing if no batch file is present).
 
         :param sg_publish_data: Shotgun data dictionary with all the standard publish fields.
+        :param build_new: Hint about if we should build a new batch group from the clip or use the latest batch file
         :type sg_publish_data: dict
+        :type build_new: bool
         """
-        # Determines published files
-        sg_filters = [["id", "is", sg_publish_data["id"]]]
-        sg_fields = ["sg_published_files",
-                     "code"
-                     ]
 
+        app = self.parent
+        app.log_debug("Adding a batch group using '%s'" % sg_publish_data)
+
+        # Query the Shotgun database about what we need
+        sg_filters = [["id", "is", sg_publish_data["id"]]]
+        sg_fields = ["sg_published_files",  # List of linked PublishedFile
+                     "code",  # Name of the Shot
+                     "sg_versions",  # List of linked Version
+                     "sg_sequence"  # Linked Sequence
+                     ]
         sg_type = "Shot"
 
         sg_info = self.parent.shotgun.find_one(
@@ -247,40 +296,620 @@ class FlameActions(HookBaseClass):
 
         # Checks that we have the necessary info to proceed.
         if not all(f in sg_info for f in sg_fields):
-            raise FlameActionError("Cannot load a Batch Group from Shotgun using this {}".format(sg_type))
+            raise FlameActionsError("Cannot load a Batch Group from Shotgun using this {}".format(sg_type))
 
-        batch_path = self._get_batch_path_from_published_files(sg_info)
-        if batch_path and os.path.exists(batch_path):
-            flame.batch.create_batch_group(sg_publish_data["code"])
-            flame.batch.go_to()
-            flame.batch.load_setup(batch_path)
-            flame.batch.organize()
+        # Create a new batch_group using this Shot
+        if build_new:
+            self._create_batch_group(sg_info)
+
+        # Load the more recent batch file present on this Shot
         else:
-            raise FlameActionError("Batch file missing")
+            # Try to get the batch file from the current Shot
+            batch_path = self._get_batch_path_from_published_files(sg_info)
+            app.log_debug("Found Batch setup path: %s" % batch_path)
+            # We found a batch file so let's import it
+            if batch_path and self._exists(batch_path):
+                app.log_debug("Creating the '%s' batch group using '%s'" % (sg_publish_data['code'], batch_path))
+                flame.batch.go_to()
+                flame.batch.create_batch_group(sg_publish_data["code"])
+                if not flame.batch.load_setup(batch_path):
+                    raise FlameActionsError("Unable to load the Batch Setup")
+                flame.batch.organize()
+
+            # No batch file found
+            else:
+                raise FlameActionsError("No setup to load")
+
+    ##############################################################################################################
+    # interface to the action hook configuration
+
+    @property
+    def supported_clip_types(self):
+        """
+        Query the action_mappings entry to get every Published Type that's considered as a clip
+
+        :return: List of Published Type
+        :rtype: [str]
+        """
+
+        return [entry[0] for entry in self.parent.get_setting("action_mappings", {}).items() if
+                CLIP_ACTION in entry[1]]
+
+    @property
+    def supported_batch_types(self):
+        """
+        Query the action_mappings entry to get every Published Type that's considered as a Batch file
+
+        :return: List of Published Type
+        :rtype: [str]
+        """
+
+        return [entry[0] for entry in self.parent.get_setting("action_mappings", {}).items() if
+                BATCH_ACTION in entry[1]]
+
+    @property
+    def configuration(self):
+        """
+        Direct interface to the tk-flame actions configuration dictionary.
+
+        :return: Dictionary of configuration
+        :rtype: dict
+        """
+
+        return self.parent.get_setting("action_hook_config", {})
+
+    @property
+    def import_location(self):
+        """
+        Schematic Reel where the loader should import the clips.
+
+        This is defined by the "import_clip_location" entry of the configuration dictionary
+
+        :return: Location to import clip
+        :rtype: str
+        """
+
+        return self.configuration.get("import_clip_location")
+
+    @property
+    def want_write_file_node(self):
+        """
+        Define if we want to link a Write File node to a new Batch group
+
+        This is defined by the "write_file_node" entry of the configuration dictionary
+
+        Flame 2018.3 or above is needed for this functionality
+
+        :return: Hint about using a linking a Write File node
+        :rtype: bool
+        """
+
+        if sgtk.platform.current_engine().is_version_less_than("2018.3"):
+            return False
+
+        return self.configuration.get("write_file_node")
+
+    @property
+    def use_template(self):
+        """
+        Define if we want to use templates to generate de Write File node attribute.
+
+        This is defined by the "write_file_use_template" entry of the configuration dictionary
+
+        :return: Hint about using the templates to generate the Write File node attribute.
+        :rtype: bool
+        """
+
+        return self.configuration.get("write_file_use_template")
+
+    @property
+    def media_path_pattern(self):
+        """
+        This pattern helps to setup the write_file_node by specifying where to write the medias.
+
+        This is defined by the "write_file_media_path_pattern" entry of the configuration dictionary
+
+        :return: Media path pattern
+        :type: str
+        """
+        return self.configuration.get("write_file_media_path_pattern")
+
+    @property
+    def clip_path_pattern(self):
+        """
+        This pattern helps to setup the write_file_node by specifying where to write the clips.
+
+        This is defined by the "write_file_clip_path_pattern" entry of the configuration dictionary
+
+        :return: Clip path pattern
+        :type: str
+        """
+        return self.configuration.get("write_file_clip_path_pattern")
+
+    @property
+    def setup_path_pattern(self):
+        """
+        This pattern helps to setup the write_file_node by specifying where to write the setups.
+
+        This is defined by the "write_file_setup_path_pattern" entry of the configuration dictionary
+
+        :return: Setup path pattern
+        :type: str
+        """
+        return self.configuration.get("write_file_setup_path_pattern")
+
+    @property
+    def media_path_template(self):
+        """
+        Template built from the "write_file_media_path_template" entry from the configuration dictionary.
+
+        This template helps to setup the write_file_node by specifying where to write the medias
+
+        :return: Media pattern path template
+        :rtype: TemplatePath
+        """
+
+        template_name = self.configuration.get("write_file_media_path_template")
+        return self.parent.sgtk.templates.get(template_name)
+
+    @property
+    def media_file_type(self):
+        """
+        Media type to use with the Write File node.
+
+        This is defined by the "write_file_media_type" entry of the configuration dictionary
+
+        :return: Media file type
+       :rtype: str
+        """
+
+        return self.configuration.get("write_file_media_type")
+
+    @property
+    def clip_path_template(self):
+        """
+        Template built from the "write_file_clip_path_template" entry from the configuration dictionary.
+
+        This template helps to setup the write_file_node by specifying where to write the clips
+
+        :return: Clip path template
+        :rtype: TemplatePath
+        """
+
+        template_name = self.configuration.get("write_file_clip_path_template")
+        return self.parent.sgtk.templates.get(template_name)
+
+    @property
+    def setup_path_template(self):
+        """
+        Template built from the "write_file_setup_path_template" entry from the configuration dictionary.
+
+        This template helps to setup the write_file_node by specifying where to write the setup
+
+        :return: Setup path template
+        :rtype: TemplatePath
+        """
+
+        template_name = self.configuration.get("write_file_setup_path_template")
+        return self.parent.sgtk.templates.get(template_name)
+
+    @property
+    def version_padding(self):
+        """
+        Padding to use on the version attribute on the Write File node.
+
+        This is defined by the "write_file_version_padding" entry of the configuration dictionary
+
+        :return: Write File version padding
+        :rtype: int
+        """
+
+        return self.configuration.get("write_file_version_padding")
+
+    @property
+    def frame_padding(self):
+        """
+        Padding to use on the frame attribute on the Write File node.
+
+        This is defined by the "write_file_frame_padding" entry of the configuration dictionary
+
+        :return: Write File frame padding
+        :rtype: int
+        """
+
+        return self.configuration.get("write_file_frame_padding")
 
     ##############################################################################################################
     # helper methods which can be subclassed in custom hooks to fine tune the behavior of things
 
+    def _create_batch_group(self, shot_info):
+        """
+        Create a new Batch group using the current Shot information
+
+        :param shot_info: Metadata of the current Shot
+        :type shot_info: dict
+        """
+        app = self.parent
+
+        app.log_debug("Creating the batch group using '%s'" % shot_info)
+
+        # Get the clips from sg_published_files
+        clips = self._get_clips_from_published_files(shot_info)
+
+        app.log_debug("Found clips %s" % clips)
+
+        if not clips:
+            raise FlameActionsError("No clip to load")
+
+        # Get the frame information of the Batch group from the sg_versions
+        start_frame, last_frame = self._extract_frame_range_from_version(shot_info)
+
+        # Start to build the Batch Group attribute dictionary
+        batch_group_info = {"name": shot_info["code"]}
+
+        # Add frame information to the batch_group dictionary if available
+        if None not in [start_frame, last_frame]:
+            batch_group_info["start_frame"] = start_frame
+            batch_group_info["duration"] = (int(last_frame) - int(start_frame)) + 1
+
+        # Create the Batch Group
+        flame.batch.go_to()
+
+        if not flame.batch.create_batch_group(**batch_group_info):
+            raise FlameActionsError("Unable to create a Batch Group")
+
+        have_write_file = False
+
+        # Import every clips!
+        for clip in clips:
+            if self._exists(clip["path"]):
+                app.log_debug("Importing '%s'" % clip["path"])
+
+                node = flame.batch.import_clip(clip["path"], self.import_location)
+                if node:
+                    if self.want_write_file_node and not have_write_file:
+                        clip["Shot Name"] = shot_info["code"]
+                        clip["Sequence Name"] = shot_info["sg_sequence"]["name"]
+
+                        self._link_write_node(node, clip)
+
+                        have_write_file = True
+                else:
+                    self.parent.log_warning("Unable to load '%s'" % clip["path"])
+            else:
+                self.parent.log_warning("File not found on disk - '%s'" % clip["path"])
+
+        flame.batch.organize()
+
+    def _build_write_file_attribute(self, clip):
+        """
+        Build a dictionary of Write File node attribute using the clip information and the current context.
+
+        :returns: Dictionary of Write file node attribute.
+        :rtype: dict
+
+        """
+        app = self.parent
+        app.log_debug("Building write file node attribute for '%s' using '%s'" % (clip, self.configuration))
+
+        fields = {
+            "Sequence": clip["Sequence Name"],
+            "Shot": "<shot name>",
+            "segment_name": clip["Sequence Name"],
+            "version": "<version>",
+            "SEQ": "<frame>"
+        }
+
+        file_format = {
+            "exr": "OpenEXR",
+            "dpx": "Dpx"
+        }
+        # The order is important when setting the attributes
+        write_file_info = collections.OrderedDict()
+
+        # Enable create_clip_path and include_setup
+        write_file_info["create_clip"] = True
+
+        # Enable include_setup_path
+        write_file_info["include_setup"] = True
+
+        # Enable version_number
+        write_file_info["version_mode"] = "Custom Version"
+
+        # The write file node have to be one version higher than the current clip
+        write_file_info["version_number"] = clip["info"]["version_number"] + 1
+
+        write_file_info["shot_name"] = clip["Shot Name"]
+        write_file_info["name"] = clip["Shot Name"]
+
+        media_path_set, clip_path_set, setup_path_set = [False] * 3
+
+        # Specify where to write our media
+        if self.use_template and self.media_path_template:
+            media_root, media_path, media_ext = self._build_path_from_template(self.media_path_template, fields)
+            write_file_info["media_path"] = media_root
+            write_file_info["media_path_pattern"] = media_path
+            write_file_info["file_type"] = file_format.get(media_ext)
+
+            keys = self.media_path_template.keys
+            write_file_info["version_padding"] = int(keys['version'].format_spec)
+            write_file_info["frame_padding"] = int(keys['SEQ'].format_spec)
+
+            media_path_set = True
+
+        if not media_path_set and self.media_path_pattern:
+            write_file_info["media_path_pattern"] = self.media_path_pattern.format(**fields)
+
+        if "version_padding" not in write_file_info and self.version_padding:
+            write_file_info["version_padding"] = self.version_padding
+
+        if "frame_padding" not in write_file_info and self.frame_padding:
+            write_file_info["frame_padding"] = self.frame_padding
+
+        if "file_type" not in write_file_info and self.media_file_type:
+            write_file_info["file_type"] = self.media_file_type
+
+        # Create a .clip file
+        if self.use_template and self.clip_path_template:
+            clip_root, clip_path, clip_ext = self._build_path_from_template(self.clip_path_template, fields)
+            write_file_info["create_clip_path"] = clip_path
+
+            clip_path_set = True
+
+        if not clip_path_set and self.clip_path_pattern:
+            write_file_info["create_clip_path"] = self.clip_path_pattern.format(**fields)
+
+        # Create a .batch file
+        if self.use_template and self.setup_path_template:
+            setup_root, setup_path, setup_ext = self._build_path_from_template(self.setup_path_template, fields)
+            write_file_info["include_setup_path"] = setup_path
+
+            setup_path_set = True
+
+        if not setup_path_set and self.setup_path_pattern:
+            write_file_info["include_setup_path"] = self.setup_path_pattern.format(**fields)
+
+        return write_file_info
+
+    def _link_write_node(self, node, clip):
+        """
+        Links a write file node to the provided clip.
+
+        :param node: Flame node to attach a Write File node to
+        :param clip: Clip information of the node
+        :type node: PyNode
+        :type clip: dict
+        """
+
+        app = self.parent
+        app.log_debug("Linking a Write File node to '%s'" % clip)
+
+        # Build the Write File node attribute dict
+        param = self._build_write_file_attribute(clip)
+
+        # Create the write file node
+        write_node = flame.batch.create_node("Write File")
+
+        if not write_node:
+            raise FlameActions("Unable to create Write File node")
+
+        # Param is a OrderedDict so the attributes are set in the right order
+        for attribute, value in param.items():
+            if hasattr(write_node, attribute):
+                app.log_debug("Write File %s = %s" % (attribute, value))
+                setattr(write_node, attribute, value)
+            else:
+                self.parent.log_warning("Unknown attribute: %s" % attribute)
+
+        # Connect the Write File node to the node
+        flame.batch.connect_nodes(node, "Default", write_node, "Front")
+
+    def _get_info_from_published_files(self, sg_published_files):
+        """
+        Gets a list of paths associated to a list of published files. Specific to Flame as some paths
+        need to be custom formatted (ie frames), and others need to be ignored (for instance, Batch files)
+
+        :param sg_published_files: A list of Shotgun data dictionary with all the standard publish fields.
+        :type sg_published_files: [dict]
+        :returns: A list of published file information.
+        :rtype: [dict]
+        """
+        app = self.parent
+
+        app.log_debug("Getting path and frame range information from '%s'" % sg_published_files)
+        # First loop populates the list of valid published files in the shot
+        published_files = []
+
+        for published_file in sg_published_files:
+            # Gets paths to published files
+            sg_filters = [["id", "is", published_file["id"]]]
+            sg_fields = ["path", "published_file_type", "version", "version_number", "code", "updated_at", "name"]
+            sg_type = "PublishedFile"
+
+            file_info = self.parent.shotgun.find_one(sg_type, filters=sg_filters, fields=sg_fields)
+
+            try:
+                # Get the local path of the published file
+                path = self.get_publish_path(file_info)
+            except TankError as error:
+                # Unable to get the path so log it and ignore this published file
+                self.parent.log_warning(str(error))
+                continue
+
+            # Eliminates PublishedFiles with an invalid local path
+            if path and self._exists(path):
+                published_files.append({"path": path, "info": file_info})
+            elif '%' in path:
+                path_info = self._handle_frame_range(path)
+
+                published_files.append(
+                    {
+                        "path": path_info["path"],
+                        "frame_range":
+                            {
+                                "start_frame": int(path_info["start_frame"]),
+                                "end_frame": int(path_info["end_frame"])
+                            },
+                        "info": file_info
+                    }
+                )
+            else:
+                self.parent.log_warning("File not found on disk - '%s'" % path)
+
+        app.log_debug("PublishedFile info found: %s" % published_files)
+
+        return published_files
+
+    def _get_batch_path_from_published_files(self, sg_info):
+        """
+        Gets the Batch File from a published files dictionary
+
+        :param sg_info: A list of Shotgun data dictionary containing the published files.
+        :type sg_info: dict
+        :returns: The path to the batch file.
+        :rtype: str
+        """
+        app = self.parent
+        app.log_debug("Getting batch path from the published files information")
+        published_files_paths = self._get_info_from_published_files(
+            sg_info["sg_published_files"]
+        )
+
+        batchs = []
+
+        for published_file in published_files_paths:
+            # Gets paths to published files
+
+            info = published_file["info"]
+
+            # We only want to play with batch file type
+            if info["published_file_type"]["name"] in self.supported_batch_types:
+                batchs.append(published_file)
+
+        # We want to get the one with the latest iteration
+        return self._latest_version_filter(batchs)[0]["path"] if batchs else None
+
+    def _get_clips_from_published_files(self, sg_info):
+        """
+        Gets the clip files information from a published files dictionary
+
+        :param sg_info: A list of Shotgun data dictionary containing the published files.
+        :type sg_info: dict
+        :returns: A list of supported published file data.
+        :rtype: [dict]
+        """
+
+        app = self.parent
+        app.log_debug("Getting clips from the published files information")
+
+        published_files_paths = self._get_info_from_published_files(
+            sg_info["sg_published_files"]
+        )
+
+        clips = []
+
+        for published_file in published_files_paths:
+            # Gets paths to published files
+
+            info = published_file["info"]
+
+            # We don't want to play with file types that we don't support
+            if info["published_file_type"]["name"] in self.supported_clip_types:
+                clips.append(published_file)
+
+        return self._latest_version_filter(clips)
+
+    def _extract_frame_range_from_version(self, sg_info):
+        """
+        Try to get the frame range from the latest version of the entity.
+
+        :param sg_info: Entity metadata
+        :type sg_info: dict
+        :return: Tuple containing first and last frame
+        :rtype: ( int, int )
+        """
+        app = self.parent
+        app.log_debug("Getting version from '%s'" % sg_info)
+        first_frame = None
+        last_frame = None
+
+        if "sg_versions" in sg_info and len(sg_info["sg_versions"]) > 0:
+            latest_update = None
+
+            for version in sg_info["sg_versions"]:
+                filters = [["id", "is", version["id"]]]
+                fields = ["frame_range", "updated_at"]
+                entity_type = "Version"
+
+                version_data = self.parent.shotgun.find_one(
+                    entity_type, filters=filters, fields=fields
+                )
+
+                # Checks that we have the necessary info to proceed.
+                if not all(f in version_data for f in fields):
+                    raise FlameActionsError("Cannot extract frame range for \n {}".format(sg_info))
+
+                # Only if the frame_range is defined
+                if version_data["frame_range"] is not None:
+                    try:
+                        # The current sg_version is more recent that the one we use
+                        if latest_update is None or latest_update < version_data["updated_at"]:
+                            latest_update = version_data["updated_at"]
+                            first_frame, last_frame = list(map(int, version_data["frame_range"].split("-")))
+                    except (AttributeError, ValueError):
+                        pass
+
+        app.log_debug("Found first frame = %s and last frame = %s" % (first_frame, last_frame))
+        return first_frame, last_frame
+
     @staticmethod
-    def _handle_frame_range(path, frame_range):
+    def _latest_version_filter(published_files_info):
+        """
+        Filter that keep the newest version of the Published Files.
+
+        :param published_files_info: List of PublishedFile metadata
+        :type published_files_info: [dict]
+        :return: List of the latest PublishedFile metadata
+        :rtype: [dict]
+        """
+
+        latest_clips = {}
+
+        for clip in published_files_info:
+            other_clip = latest_clips.get(clip["info"]["name"])
+
+            # There's no other version of the clip so let's add this one
+            if other_clip is None:
+                latest_clips[clip["info"]["name"]] = clip
+            else:
+                # The other clip have a greater version so let's keep it
+                if other_clip["info"]["version_number"] > clip["info"]["version_number"]:
+                    continue
+
+                # The other clip have a smaller version so let's swap them
+                elif other_clip["info"]["version_number"] < clip["info"]["version_number"]:
+                    latest_clips[clip["info"]["name"]] = clip
+
+                # They both have the same version so let's keep the newest one
+                else:
+                    if other_clip["info"]["updated_at"] < clip["info"]["updated_at"]:
+                        latest_clips[clip["info"]["name"]] = clip
+
+        return latest_clips.values()
+
+    @staticmethod
+    def _handle_frame_range(path):
         """
         Takes a path and inserts formatted frame range for later use in Flame,
         using old-style Python formatting normally reserved for ints.
 
         :param path: The path containing the formatting character.
-        :param frame_range: Frame range, two ints in a str separated by a '-'
         :type path: str
-        :type frame_range: str
-
-        :return: The path with the frame range.
-        :rtype: str
+        :return: Dictionary containing the sequence path, the first_frame and the last_frame
+        :rtype: dict
         """
-        # Gets the two range numbers we need
-        ranges = [int(x) for x in str.split(frame_range, '-')]
 
-        # Checks that we have the info we need
-        if not ranges or len(ranges) != 2:
-            raise Exception("No ranges found")
+        ranges = FlameActions._guess_frame_range(path)
 
         # Cuts off everything after the position of the formatting char.
         path_end = path[path.find('%'):]
@@ -292,93 +921,134 @@ class FlameActions(HookBaseClass):
         start_frame = formatting_str % int(ranges[0])
         end_frame = formatting_str % int(ranges[1])
 
-        # Generates back the frame range, now formatted
-        frame_range = "[{}-{}]".format(
-            start_frame, end_frame
-        )
+        if None in [start_frame, end_frame]:
+            raise FlameActionsError("File not found on disk - '%s'" % path)
+        elif start_frame == end_frame:
+            frame_range = start_frame
+        else:
+            # Generates back the frame range, now formatted
+            frame_range = "[{}-{}]".format(
+                start_frame, end_frame
+            )
 
-        # Inserts the frame range into the path
-        return path.replace(formatting_str, frame_range)
+        return {"path": path.replace(formatting_str, frame_range), "start_frame": start_frame, "end_frame": end_frame}
 
-    def _get_paths_from_published_files(self, sg_published_files):
+    @staticmethod
+    def _guess_frame_range(path):
         """
-        Gets a list of paths associated to a list of published files. Specific to Flame as some paths
-        need to be custom formatted (ie frames), and others need to be ignored (for instance, Batch files)
+        Try to get the sequence's frame range from the path
 
-        :param sg_published_files: A list of Shotgun data dictionary with all the standard publish fields.
-        :returns: The paths to the shots.
-        :rtype: list
+        :param path: Path of the sequence containing a frame pattern
+        :type path: str
+        :return: Tuple containing the first and the last frame number of the sequence or tuple of None if failure
+        :rtype: ( int, int ) or ( None, None )
         """
+        folder, file_name = ntpath.split(path)
+        match = re.match(r"(.*)(%\d+d)(.+)", file_name)
 
-        # First loop populates the list of valid published files in the shot
-        published_files = []
+        if not match:
+            raise FlameActionsError("Cannot detect frame pattern for '%s'" % path)
 
-        for published_file in sg_published_files:
-            # Gets paths to published files
-            sg_filters = [["id", "is", published_file["id"]]]
-            sg_fields = ["path", "published_file_type", "version"]
-            sg_type = "PublishedFile"
+        frame_list = []
 
-            file_info = self.parent.shotgun.find_one(sg_type, filters=sg_filters, fields=sg_fields)
+        # The frame numbers have to match a certain number of digits
+        frame_len = int(match.group(2)[1:-1])
 
-            try:
-                path = self.get_publish_path(file_info)
-            except TankError:
-                # We can't get the publish path so let's ignore this publish file
+        # Lets retrieve all the files that's in the folder of the file to match
+        files = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
+
+        for f in files:
+            # It doesn't match our pattern
+            if not f.startswith(match.group(1)) or not f.endswith(match.group(3)):
                 continue
 
-            # Eliminates PublishedFiles with an invalid local path
-            if path and os.path.exists(path):
-                published_files.append({"path": path, "info": file_info})
-            elif '%' in path:
-                if file_info["version"] is not None:
-                    sg_filters = [["id", "is", file_info["version"]["id"]]]
-                else:
-                    continue
-                sg_fields = ["frame_range"]
-                sg_type = "Version"
+            # Lets isolate the potential frame number from the file name
+            frame = f[len(match.group(1)):-len(match.group(3))]
 
-                vers_info = self.parent.shotgun.find_one(
-                    sg_type, filters=sg_filters, fields=sg_fields
-                )
+            # It's not a frame that match our pattern
+            if len(frame) != frame_len and not frame.isdigit():
+                continue
 
-                # Unfortunately, we can't do simple formatting here as %<num>d
-                # old style Python formatting does not support getting a frame
-                # range. Thus we need to parse it ourselves
-                new_path = self._handle_frame_range(
-                    path, vers_info["frame_range"]
-                )
+            # Let's add the frame number of the file that match our pattern
+            frame_list.append(frame)
 
-                if new_path and len(new_path) != 0:
-                    path = new_path
+        frame_list.sort()
 
-                published_files.append({"path": path, "info": file_info})
-            else:
-                raise FlameActionError("File not found on disk - '%s'" % path)
+        if len(frame_list) >= 2:
+            # We have at least 2 frame so let's return first and the last frame number
+            return frame_list[0], frame_list[-1]
+        elif len(frame_list) == 1:
+            # We only have one frame that match so let's return the same frame as begin and end frame
+            return frame_list[0], frame_list[0]
+        else:
+            # Let's return None because nothing match our pattern
+            return None, None
 
-        return published_files
-
-    def _get_batch_path_from_published_files(self, sg_info):
+    @staticmethod
+    def _exists(media_path):
         """
-        Gets the Batch File from a published files dictionary
+        Checks if the path exists directly or as a sequence
 
-        :param sg_info: A list of Shotgun data dictionary containing the published files.
-        :returns: The path to the batch file.
-        :rtype: str
+        :param media_path: Potential media path
+        :type media_path: str
+        :return: Return if the media_path exists
+        :rtype: bool
         """
 
-        published_files_paths = self._get_paths_from_published_files(
-            sg_info["sg_published_files"]
-        )
+        # Check if the path exists
+        if os.path.exists(media_path):
+            return True
 
-        batchs = []
+        folder, file_name = ntpath.split(media_path)
 
-        for published_file in published_files_paths:
-            # Gets paths to published files
+        # Try to check if the path is sa sequence
+        match = re.match(r"(.+\.)((?:\[\d+-\d+\])|(?:\d+))(\..+)", file_name)
 
-            info = published_file["info"]
+        if not match:
+            # The path is not a sequence
+            return False
 
-            if info["published_file_type"]["name"] == "Flame Batch File":
-                batchs.append(published_file["path"])
+        # Get the first and last frame of the sequence
+        first, last = match.group(2).replace("[", "").replace("]", "").split("-")
 
-        return max(batchs) if batchs else None
+        # Get the frame value padding length
+        frame_size = len(first)
+
+        # Check if at least one frame in the sequence exists
+        for frame in range(int(first), int(last)):
+            # Apply frame padding
+            frame = "0" * (frame_size - len(str(frame))) + str(frame)
+
+            # Build frame file name
+            file_name = match.group(1) + frame + match.group(3)
+
+            # Check if frame exists
+            if os.path.exists(os.path.join(folder, file_name)):
+                return True
+
+        return False
+
+    @staticmethod
+    def _build_path_from_template(template, fields):
+        """
+        Build a path from a template and from a clip information dictionary.
+
+        :param template: Template to use to build the path
+        :param fields: Dictionary containing Shotgun Template keys and theirs values
+        :type template: TemplatePath
+        :type fields: dict
+        :return: Tuple containing the project root, the media path and the extension
+        :rtype: ( str, str, str )
+        """
+
+        # Build the path from the template
+        path = template._apply_fields(fields, ignore_types=["version", "SEQ", "Shot", "segment_name"]) \
+                   .replace(template.root_path, "", 1)[1:]  # remove the root path from the path and the first "/"
+
+        # Get the extension
+        ext = path.split(".")[-1]
+
+        # Remove the extension
+        path = ".".join(path.split(".")[0:-1])
+
+        return template.root_path, path, ext.lower()

--- a/info.yml
+++ b/info.yml
@@ -31,38 +31,6 @@ configuration:
         default_value: "{self}/{engine_name}_actions.py"
         description: Hook which contains all methods for action management.
 
-    action_hook_config:
-        type: dict
-        description: Control certain behaviour of the hook
-        default_value: {}
-        default_value_tk-flame:
-            # Location where import_clip should put the clips
-            import_clip_location: "Schematic Reel 1"
-            # Hint about if the loader should create a write file node
-            write_file_node: true
-            # Hint about if the loader should use the defined templates
-            write_file_use_template: true
-            # Template to use for Open Clip path
-            write_file_clip_path_template: "flame_shot_clip"
-            # Pattern to use for the Open clip path instead of the if the template is not available
-            write_file_clip_path_pattern: "{Shot}"
-            # Template to use for the Batch Setup path
-            write_file_setup_path_template: "flame_shot_batch"
-            # Pattern to use for the Batch Setup path if the template is not available
-            write_file_setup_path_pattern: "<shot name>.v<version>"
-            # Template to use for the media path, the media pattern and the file type
-            write_file_media_path_template: "flame_shot_comp_exr"
-            # Pattern to use for the media pattern if the template is not available
-            write_file_media_path_pattern: "<shot name>_{segment_name}_v<version>.<frame>"
-            # Location to use for the media path if the template is not available
-            write_file_media_path_root: "/var/tmp"
-            # Type to use for the media if the template is not available
-            write_file_media_type: "OpenEXR"
-            # Frame padding to use if the template is not available
-            write_file_frame_padding: 04
-            # Version padding to use if the template is not available
-            write_file_version_padding: 03
-
     filter_publishes_hook:
         type: hook
         default_value: "{self}/filter_publishes.py"

--- a/info.yml
+++ b/info.yml
@@ -31,6 +31,36 @@ configuration:
         default_value: "{self}/{engine_name}_actions.py"
         description: Hook which contains all methods for action management.
 
+    action_hook_config:
+        type: dict
+        description: Control certain behaviour of the hook
+        default_value: {}
+        default_value_tk-flame:
+            # Location where import_clip should put the clips
+            import_clip_location: "Schematic Reel 1"
+            # Hint about if the loader should create a write file node
+            write_file_node: true
+            # Hint about if the loader should use the defined templates
+            write_file_use_template: true
+            # Template to use for Open Clip path
+            write_file_clip_path_template: "flame_shot_clip"
+            # Pattern to use for the Open clip path instead of the if the template is not available
+            write_file_clip_path_pattern: "{Shot}"
+            # Template to use for the Batch Setup path
+            write_file_setup_path_template: "flame_shot_batch"
+            # Pattern to use for the Batch Setup path if the template is not available
+            write_file_setup_path_pattern: "<shot name>.v<version>"
+            # Template to use for the media path, the media pattern and the file type
+            write_file_media_path_template: "flame_shot_comp_exr"
+            # Pattern to use for the media pattern if the template is not available
+            write_file_media_path_pattern: "<shot name>_{segment_name}_v<version>.<frame>"
+            # Type to use for the media if the template is not available
+            write_file_media_type: "OpenEXR"
+            # Frame padding to use if the template is not available
+            write_file_frame_padding: 04
+            # Version padding to use if the template is not available
+            write_file_version_padding: 03
+
     filter_publishes_hook:
         type: hook
         default_value: "{self}/filter_publishes.py"
@@ -79,6 +109,7 @@ configuration:
             Rendered Image: [load_clip]
             Image: [load_clip]
             Movie: [load_clip]
+            Texture: [load_clip]
 
     entity_mappings:
         type: dict
@@ -86,7 +117,7 @@ configuration:
                      inside the actions hook.
         default_value: {}
         default_value_tk-flame:
-            Shot: [load_batch]
+            Shot: [load_batch, create_batch]
 
     entities:
         default_value:

--- a/info.yml
+++ b/info.yml
@@ -54,6 +54,8 @@ configuration:
             write_file_media_path_template: "flame_shot_comp_exr"
             # Pattern to use for the media pattern if the template is not available
             write_file_media_path_pattern: "<shot name>_{segment_name}_v<version>.<frame>"
+            # Location to use for the media path if the template is not available
+            write_file_media_path_root: "/var/tmp"
             # Type to use for the media if the template is not available
             write_file_media_type: "OpenEXR"
             # Frame padding to use if the template is not available


### PR DESCRIPTION
DESCRIPTION

This adds functionality to the tk-flame part of the Shotgun Loader

Now a user can Create a batch group using the supported clips linked to
a Shot entity. Once this Batch group is created, if the user have the
right context (Classic integration for now with the tk-flame-export),
a Render will trigger a publish export to Shotgun.

There's also more configuration options. Theses options allow the user
to change certain behavior of the loader without having to play in the
Python code.

Finally, there's more documentation and more debug logging to be able to
do better troubleshooting.