### PR TITLE
#43996 Clicking play in sg panel navigates to sg media player

### DIFF
--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -164,10 +164,14 @@ class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
         
         # if there is a version associated, add View in Screening Room Action
         if sg_item.get("version"):
+
+            # redirect to std shotgun player, same as you go to if you click the
+            # play icon inside of the shotgun web ui
             sg_url = sgtk.platform.current_bundle().shotgun.base_url
-            url = "%s/page/screening_room?entity_type=%s&entity_id=%d" % (sg_url, 
-                                                                          sg_item["version"]["type"], 
-                                                                          sg_item["version"]["id"])                    
+            url = "%s/page/media_center?type=Version&id=%d" % (
+                sg_url,
+                sg_item["version"]["id"]
+            )
             
             fn = lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl(url))                    
             a = QtGui.QAction("View in Screening Room", None)


### PR DESCRIPTION
This changes the behaviour of the sg panel so that if you click the "play" icon for a version, it will navigate you to the sg media center page rather than screening room which was previously the case. Back when we originally wrote this code, the media center was not yet released and they did not have proper urls that you can navigate to. This change aligns the behaviour in the loader with what you get in the the sg web app.