### PR TITLE
Create reference using relative path instead of absolute path in Maya

### DIFF
--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -192,8 +192,11 @@ class MayaActions(HookBaseClass):
         namespace = "%s %s" % (sg_publish_data.get("entity").get("name"), sg_publish_data.get("name"))
         namespace = namespace.replace(" ", "_")
                 
-        pm.system.createReference(path, 
-                                  loadReferenceDepth= "all", 
+        # create reference using relative path instead of absolute path
+        current_path = cmds.file(q=True, sn=True)
+        relative_path = os.path.relpath(path, os.path.dirname(current_path))
+        pm.system.createReference(relative_path, 
+                                  loadReferenceDepth="all", 
                                   mergeNamespacesOnClash=False, 
                                   namespace=namespace)
 


### PR DESCRIPTION
When we open up an empty Maya scene and load some assets published through different OS, everything looks fine. 
But if we open a Maya scene which have references created by loader under other OS, the path would be wrong.
For example, there is an asset located at our network storage, we use loader to create a reference in a Maya scene. At this moment, the reference we created uses path `/mnt/assets/brutus`. Then we open this Maya scene in Windows, this reference would be missed since the path of that reference cannot be found.

Using relative path could resolve this issue.