### PR TITLE
#45167 removed unicode flag from regex sub operation

### DIFF
--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -231,7 +231,9 @@ class HoudiniActions(HookBaseClass):
         # remove non alphanumeric characers from the string (houdini node names
         # must be alphanumeric). first, build a regex to match non alpha-numeric
         # characters. Then use it to replace any matches with an underscore
-        pattern = re.compile('[\W_]+', re.UNICODE)
+        
+        # cannot use special characters to create nodes
+        pattern = re.compile('[\W_]+')
         publish_name = pattern.sub('_', publish_name)
 
         # get the publish path


### PR DESCRIPTION
the Unicode flag was causing problems in regex sub operation. Houdini does not accept special characters (é, à,..) when creating nodes. We replace these by '_', along with non alphanumeric characters.