### PR TITLE
SG-5399 Added support for complex filters

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -27,6 +27,7 @@ from .delegate_publish_history import SgPublishHistoryDelegate
 from .search_widget import SearchWidget
 from .banner import Banner
 from .loader_action_manager import LoaderActionManager
+from .utils import resolve_filters
 
 from . import constants
 from . import model_item_data
@@ -1528,27 +1529,7 @@ class AppDialog(QtGui.QWidget):
         """
 
         # Resolve any magic tokens in the filters.
-        resolved_filters = []
-        for filter in setting_dict["filters"]:
-            resolved_filter = []
-            for field in filter:
-                if field == "{context.entity}":
-                    field = app.context.entity
-                elif field == "{context.project}":
-                    field = app.context.project
-                elif field == "{context.project.id}":
-                    if app.context.project:
-                        field = app.context.project.get("id")
-                    else:
-                        field = None
-                elif field == "{context.step}":
-                    field = app.context.step
-                elif field == "{context.task}":
-                    field = app.context.task
-                elif field == "{context.user}":
-                    field = app.context.user
-                resolved_filter.append(field)
-            resolved_filters.append(resolved_filter)
+        resolved_filters = resolve_filters(setting_dict["filters"])
         setting_dict["filters"] = resolved_filters
 
         # Construct the query model.

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -281,12 +281,12 @@ def filter_publishes(app, sg_data_list):
 
 def resolve_filters(filters):
     """
+    When passed a list of filters, it will resolve strings found in the filters using the context.
+    For example: '{context.user}' could get resolved to {'type': 'HumanUser', 'id': 86, 'name': 'Philip Scadding'}
 
-    When passed a list of filters, it will resolve strings found in the filters using the context
-    example: '{context.user}' could get resolved to {'type': 'HumanUser', 'id': 86, 'name': 'Philip Scadding'}
-
-    :param filters: a list of filters as found in the info.yml config
-    should be in the format: [[task_assignees, is, '{context.user}'],[sg_status_list, not_in, [fin,omt]]]
+    :param filters: A list of filters that has usually be defined by the user or by default in the environment yml
+    config or the app's info.yml. Supports complex filters as well. Filters should be passed in the following format:
+    [[task_assignees, is, '{context.user}'],[sg_status_list, not_in, [fin,omt]]]
 
     :return: A List of filters for use with the shotgun api
     """

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
 
@@ -276,3 +277,45 @@ def filter_publishes(app, sg_data_list):
         sg_data_list = []
 
     return sg_data_list
+
+
+def resolve_filters(filters):
+    """
+
+    When passed a list of filters, it will resolve strings found in the filters using the context
+    example: '{context.user}' could get resolved to {'type': 'HumanUser', 'id': 86, 'name': 'Philip Scadding'}
+
+    :param filters: a list of filters as found in the info.yml config
+    should be in the format: [[task_assignees, is, '{context.user}'],[sg_status_list, not_in, [fin,omt]]]
+
+    :return: A List of filters for use with the shotgun api
+    """
+    app = sgtk.platform.current_bundle()
+
+    resolved_filters = []
+    for filter in filters:
+        if type(filter) is dict:
+            resolved_filter = {
+                "filter_operator": filter["filter_operator"],
+                "filters": resolve_filters(filter["filters"])}
+        else:
+            resolved_filter = []
+            for field in filter:
+                if field == "{context.entity}":
+                    field = app.context.entity
+                elif field == "{context.step}":
+                    field = app.context.step
+                elif field == "{context.project}":
+                    field = app.context.project
+                elif field == "{context.project.id}":
+                    if app.context.project:
+                        field = app.context.project.get("id")
+                    else:
+                        field = None
+                elif field == "{context.task}":
+                    field = app.context.task
+                elif field == "{context.user}":
+                    field = app.context.user
+                resolved_filter.append(field)
+        resolved_filters.append(resolved_filter)
+    return resolved_filters


### PR DESCRIPTION
Now allows complex filters to be used when specifying the filters for tabs.
For example the filters in the tab settings bellow would not work previous to the update.

```
- caption: Tasks
    entity_type: Task
    filters:
      - [project, is, "{context.project}"]
      - filter_operator: "any"
        filters:
          - [entity, type_is, Asset]
          - [entity, type_is, Shot]
```

I have taken the code from the [workfiles2 way of resolving the filters](https://github.com/shotgunsoftware/tk-multi-workfiles2/blob/master/python/tk_multi_workfiles/util.py#L282-L314). I've also moved the logic for resolving filters out into utils, as this is what wf2 does as well.

However I also noticed that the workfiles way of doing it doesn't resolve the project from the context, so I've made a hybrid of the two bits of logic.



For SG-5399