### PR TITLE
SG-6836: Implements a hard_refresh method on the publish type model.

### DIFF
--- a/python/tk_multi_loader/model_publishtype.py
+++ b/python/tk_multi_loader/model_publishtype.py
@@ -205,6 +205,13 @@ class SgPublishTypeModel(ShotgunModel):
                 
         # and ask the model to resort itself 
         self.sort(0)
+
+    def hard_refresh(self):
+        """
+        Clears any caches on disk, then refreshes the data.
+        """
+        super(SgPublishTypeModel, self).hard_refresh()
+        self._load_external_data()
             
     ############################################################################################
     # subclassed methods


### PR DESCRIPTION
 This ensures we end up with the "folders" type after a hard refresh of the model. This is a very minor change that pairs with an accompanying fix for ShotgunModel's hard_refresh functionality in the more general sense.