### PR TITLE
added 'additional_publish_fields' as an app setting

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -132,6 +132,15 @@ configuration:
         allows_empty: True
         default_value: []
 
+    additional_publish_fields:
+        type: list
+        description: "Additional fields to be queried on the PublishedFile entity, which will be available for the
+                      loader items to use"
+        values:
+            type: str
+        allows_empty: True
+        default_value: []
+
 
 # this app works in all engines - it does not contain
 # any host application specific commands

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -249,7 +249,8 @@ class SgLatestPublishModel(ShotgunModel):
         else:
             self._publish_type_field = "tank_type"
 
-        publish_fields = [self._publish_type_field] + constants.PUBLISHED_FILES_FIELDS
+        publish_fields = [self._publish_type_field] + constants.PUBLISHED_FILES_FIELDS \
+                         + app.get_setting("additional_publish_fields")
 
         # first add our folders to the model
         # make gc happy by keeping handle to all items

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -60,7 +60,7 @@ class SgPublishHistoryModel(ShotgunModel):
             publish_type_field = "tank_type"
 
         # fields to pull down
-        fields = [publish_type_field] + constants.PUBLISHED_FILES_FIELDS
+        fields = [publish_type_field] + constants.PUBLISHED_FILES_FIELDS + app.get_setting("additional_publish_fields")
 
         # when we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items


### PR DESCRIPTION
We wanted to use our custom fields added on the PublishedFile entities to be available in the loader hooks.