### PR TITLE
Making all signal connections use partials rather than lambdas to wor…

### DIFF
--- a/python/tk_multi_loader/loader_action_manager.py
+++ b/python/tk_multi_loader/loader_action_manager.py
@@ -10,6 +10,7 @@
 
 import sgtk
 import datetime
+from functools import partial
 import os
 import sys
 from sgtk.platform.qt import QtCore, QtGui
@@ -219,9 +220,8 @@ class LoaderActionManager(ActionManager):
             ]
 
             # Bind all the action params to a single invocation of the _execute_hook.
-            a.triggered[()].connect(
-                lambda qt_action=a, actions=actions: self._execute_hook(qt_action, actions)
-            )
+            cb = partial(self._execute_hook, a, actions)
+            a.triggered[()].connect(cb)
             a.setData(actions)
             qt_actions.append(a)
 
@@ -344,9 +344,8 @@ class LoaderActionManager(ActionManager):
                 ]
 
                 # Bind all the action params to a single invocation of the _execute_hook.
-                a.triggered[()].connect(
-                    lambda qt_action=a, actions=actions: self._execute_hook(qt_action, actions)
-                )
+                cb = partial(self._execute_hook, a, actions)
+                a.triggered[()].connect(cb)
                 a.setData(actions)
                 qt_actions.append(a)
 
@@ -355,15 +354,18 @@ class LoaderActionManager(ActionManager):
         # Add the action only when there are some paths.
         if paths:
             fs = QtGui.QAction("Show in the file system", None)
-            fs.triggered[()].connect(lambda f=paths: self._show_in_fs(f))
+            cb = partial(self._show_in_fs, paths)
+            fs.triggered[()].connect(cb)
             qt_actions.append(fs)
 
         sg = QtGui.QAction("Show details in Shotgun", None)
-        sg.triggered[()].connect(lambda f=sg_data: self._show_in_sg(f))
+        cb = partial(self._show_in_sg, sg_data)
+        sg.triggered[()].connect(cb)
         qt_actions.append(sg)
 
         sr = QtGui.QAction("Show in Media Center", None)
-        sr.triggered[()].connect(lambda f=sg_data: self._show_in_sr(f))
+        cb = partial(self._show_in_sr, sg_data)
+        sr.triggered[()].connect(cb)
         qt_actions.append(sr)
 
         return qt_actions

--- a/python/tk_multi_loader/open_publish_action_manager.py
+++ b/python/tk_multi_loader/open_publish_action_manager.py
@@ -12,7 +12,7 @@
 A specialisation of the main ActionManager class for the open publish version of the 
 loader UI.
 """
-
+from functools import partial
 from sgtk.platform.qt import QtCore, QtGui
 from .action_manager import ActionManager
 
@@ -67,7 +67,7 @@ class OpenPublishActionManager(ActionManager):
 
         # connect the default action so that the default_action_triggered
         # is emitted:
-        default_action_cb = lambda sg=sg_data: self.default_action_triggered.emit(sg)
+        default_action_cb = partial(self.default_action_triggered.emit, sg_data)
         action.triggered[()].connect(default_action_cb)
         
         return action


### PR DESCRIPTION
…k with katana

In katana, signals that are connected to lambdas return booleans rather than the desired objects. Using partials fixes this behaviour