### PR TITLE
Add publish_extra_details hook

### DIFF
--- a/hooks/publish_extra_details.py
+++ b/hooks/publish_extra_details.py
@@ -8,9 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-
-import sgtk
 from sgtk import Hook
 
 

--- a/hooks/publish_extra_details.py
+++ b/hooks/publish_extra_details.py
@@ -8,17 +8,20 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from sgtk import Hook
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
 
 
-class PublishExtraDetails(Hook):
+class PublishExtraDetails(HookBaseClass):
     """Hook that can be used to add extra fields in the details pane."""
 
-    def execute(self, sg_item, **kwargs):
+    def execute(self, entity):
         """
         Main hook entry point.
 
-        :param sg_item: published item
-        :return List: Tuple of tuples with the form (Label, Value)
+        :param entity: The entity dictionary associated with the published item to be displayed in the loader app.
+        :return: A dictionary in the form of {label: value}
+        :rtype: dictionary
         """
-        return ()
+        return {}

--- a/hooks/publish_extra_details.py
+++ b/hooks/publish_extra_details.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+import sgtk
+from sgtk import Hook
+
+
+class PublishExtraDetails(Hook):
+    """Hook that can be used to add extra fields in the details pane."""
+
+    def execute(self, sg_item, **kwargs):
+        """
+        Main hook entry point.
+
+        :param sg_item: published item
+        :return List: Tuple of tuples with the form (Label, Value)
+        """
+        return ()

--- a/info.yml
+++ b/info.yml
@@ -40,7 +40,7 @@ configuration:
     publish_extra_details_hook:
         type: hook
         default_value: "{self}/publish_extra_details.py"
-        description: Hook which contains extra fields to be displayed on the details pane.
+        description: Hook that can be used to return extra fields to be displayed for a publish in the details pane.
 
     download_thumbnails:
         type: bool

--- a/info.yml
+++ b/info.yml
@@ -37,6 +37,11 @@ configuration:
         description: Specify a hook that, if needed, can filter the raw list of publishes returned
                      from Shotgun for the current location.
 
+    publish_extra_details_hook:
+        type: hook
+        default_value: "{self}/publish_extra_details.py"
+        description: Hook which contains extra fields to be displayed on the details pane.
+
     download_thumbnails:
         type: bool
         default_value: true

--- a/python/tk_multi_loader/delegate_publish.py
+++ b/python/tk_multi_loader/delegate_publish.py
@@ -108,16 +108,18 @@ class PublishDelegate(shotgun_view.EditSelectedWidgetDelegate):
     how things get rendered.
     """
 
-    def __init__(self, view, action_manager):
+    def __init__(self, view, action_manager, status_model=None):
         """
         Constructor
 
         :param view: The view where this delegate is being used
         :param action_manager: Action manager instance
+        :param status_model: Status model manager
         """
         self._action_manager = action_manager
         self._view = view
         self._sub_items_mode = False
+        self._status_model = status_model
         shotgun_view.EditSelectedWidgetDelegate.__init__(self, view)
 
     def set_sub_items_mode(self, enabled):

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -229,10 +229,9 @@ class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
         # if there are extra fields related to published files to be displayed
         extra_details = sgtk.platform.current_bundle().execute_hook(
             "publish_extra_details_hook",
-            sg_item=sg_item,
-            get_long_name_method=self._status_model.get_long_name
+            sg_item=sg_item
         )
-        for label, value in extra_details:
+        for label, value in extra_details.iteritems():
             body_str += "%s: %s<br>" % (label, value)
 
         widget.set_text(header_str, body_str)

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -245,4 +245,3 @@ class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
         :param model_index: Model item to operate on
         """
         return PublishHistoryWidget.calculate_size()
-             

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -225,6 +225,16 @@ class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
         else:
             author_str = "Unspecified User"
         body_str = "<i>%s</i>: %s<br>" % (author_str, desc_str)
+
+        # if there are extra fields related to published files to be displayed
+        extra_details = sgtk.platform.current_bundle().execute_hook(
+            "publish_extra_details_hook",
+            sg_item=sg_item,
+            get_long_name_method=self._status_model.get_long_name
+        )
+        for label, value in extra_details:
+            body_str += "%s: %s<br>" % (label, value)
+
         widget.set_text(header_str, body_str)
         
         

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -229,7 +229,7 @@ class SgPublishHistoryDelegate(shotgun_view.EditSelectedWidgetDelegate):
         # if there are extra fields related to published files to be displayed
         extra_details = sgtk.platform.current_bundle().execute_hook(
             "publish_extra_details_hook",
-            sg_item=sg_item
+            entity=sg_item
         )
         for label, value in extra_details.iteritems():
             body_str += "%s: %s<br>" % (label, value)

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -205,14 +205,6 @@ class SgPublishListDelegate(PublishDelegate):
         small_text = "<span style='color:#2C93E2'>%s</span> by %s at %s" % (pub_type_str, 
                                                                             author_str,
                                                                             date_str)
-        # if there are extra fields related to published files to be displayed
-        extra_details = sgtk.platform.current_bundle().execute_hook(
-            "publish_extra_details_hook",
-            sg_item=sg_data,
-            get_long_name_method=self._status_model.get_long_name
-        )
-        for label, value in extra_details:
-            small_text += "<br>%s: %s" % (label, value)
 
         widget.set_text(main_text, small_text)
 

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -205,6 +205,15 @@ class SgPublishListDelegate(PublishDelegate):
         small_text = "<span style='color:#2C93E2'>%s</span> by %s at %s" % (pub_type_str, 
                                                                             author_str,
                                                                             date_str)
+        # if there are extra fields related to published files to be displayed
+        extra_details = sgtk.platform.current_bundle().execute_hook(
+            "publish_extra_details_hook",
+            sg_item=sg_data,
+            get_long_name_method=self._status_model.get_long_name
+        )
+        for label, value in extra_details:
+            small_text += "<br>%s: %s" % (label, value)
+
         widget.set_text(main_text, small_text)
 
     def sizeHint(self, style_options, model_index):

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -738,10 +738,9 @@ class AppDialog(QtGui.QWidget):
                 # if there are extra fields related to published files to be displayed
                 extra_details = sgtk.platform.current_bundle().execute_hook(
                     "publish_extra_details_hook",
-                    sg_item=sg_item,
-                    get_long_name_method=self._status_model.get_long_name
+                    entity=sg_item
                 )
-                for label, value in extra_details:
+                for label, value in extra_details.iteritems():
                     msg += __make_table_row(label, value)
 
                 self.ui.details_header.setText("<table>%s</table>" % msg)

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -204,7 +204,8 @@ class AppDialog(QtGui.QWidget):
         # set up custom delegates to use when drawing the main area
         self._publish_thumb_delegate = SgPublishThumbDelegate(self.ui.publish_view, self._action_manager)
 
-        self._publish_list_delegate = SgPublishListDelegate(self.ui.publish_view, self._action_manager)
+        self._publish_list_delegate = SgPublishListDelegate(self.ui.publish_view, self._action_manager,
+                                                            self._status_model)
 
         # recall which the most recently mode used was and set that
         main_view_mode = self._settings_manager.retrieve("main_view_mode", self.MAIN_VIEW_THUMB)

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -734,6 +734,15 @@ class AppDialog(QtGui.QWidget):
                     task_status_str = self._status_model.get_long_name(task_status_code)
                     msg += __make_table_row("Review", task_status_str)
 
+                # if there are extra fields related to published files to be displayed
+                extra_details = sgtk.platform.current_bundle().execute_hook(
+                    "publish_extra_details_hook",
+                    sg_item=sg_item,
+                    get_long_name_method=self._status_model.get_long_name
+                )
+                for label, value in extra_details:
+                    msg += __make_table_row(label, value)
+
                 self.ui.details_header.setText("<table>%s</table>" % msg)
 
                 # tell details pane to load stuff


### PR DESCRIPTION
In the details pane, puiblish history version and publish list of this app would be great to have the chance for adding extra fields like status of the published file.

A nice way to archieve this, is using a HOOK. We propose to add the hook publish_extra_details which receives a sg_item and optionally a kwargs dict and returns a tuple of tuples with the format (Label, Value).

This hook applies only for published files.

Visual example:

![image](https://user-images.githubusercontent.com/2762494/62068336-76d3a400-b1fb-11e9-8860-f72446a5d778.png)

