### PR TITLE
Replaced entity type with entity display name

### DIFF
--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -109,7 +109,8 @@ class SgPublishListDelegate(PublishDelegate):
 
         elif sg_data:
             # this is a leaf node
-            main_text = "<b>%s</b> <b style='color:#2C93E2'>%s</b>" % (sg_data["type"], field_value)
+            display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
+            main_text = "<b>%s</b> <b style='color:#2C93E2'>%s</b>" % (display_name, field_value)
             small_text = sg_data.get("description") or "No description given."
 
         widget.set_text(main_text, small_text)

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -15,6 +15,7 @@ from .model_latestpublish import SgLatestPublishModel
 
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
+shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_list import Ui_PublishListWidget

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -110,7 +110,7 @@ class SgPublishListDelegate(PublishDelegate):
 
         elif sg_data:
             # this is a leaf node
-            display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
+            display_name = shotgun_globals.get_type_display_name(sg_data["type"])
             main_text = "<b>%s</b> <b style='color:#2C93E2'>%s</b>" % (display_name, field_value)
             small_text = sg_data.get("description") or "No description given."
 

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -110,7 +110,7 @@ class SgPublishThumbDelegate(PublishDelegate):
         elif sg_data:
             # this is a leaf node
             header_text = field_value
-            details_text= sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
+            details_text = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
 
         else:
             # other value (e.g. intermediary non-entity link node like sg_asset_type)

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -111,7 +111,7 @@ class SgPublishThumbDelegate(PublishDelegate):
         elif sg_data:
             # this is a leaf node
             header_text = field_value
-            details_text = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
+            details_text = shotgun_globals.get_type_display_name(sg_data["type"])
 
         else:
             # other value (e.g. intermediary non-entity link node like sg_asset_type)

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -16,6 +16,7 @@ from .utils import ResizeEventFilter
 
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
+shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets", "views")
 
 from .ui.widget_publish_thumb import Ui_PublishThumbWidget

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -110,7 +110,7 @@ class SgPublishThumbDelegate(PublishDelegate):
         elif sg_data:
             # this is a leaf node
             header_text = field_value
-            details_text = sg_data.get("type")
+            details_text= sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk, sg_data["type"])
 
         else:
             # other value (e.g. intermediary non-entity link node like sg_asset_type)

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -650,7 +650,9 @@ class AppDialog(QtGui.QWidget):
                     desc_str = "No description entered."
 
                 msg = ""
-                msg += __make_table_row("Name", "%s %s" % (sg_data.get("type"), sg_data.get("code")))
+                display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk,
+                                                                      sg_data["type"])
+                msg += __make_table_row("Name", "%s %s" % (display_name, sg_data.get("code")))
                 msg += __make_table_row("Status", status_name)
                 msg += __make_table_row("Description", desc_str)
                 self.ui.details_header.setText("<table>%s</table>" % msg)
@@ -708,8 +710,9 @@ class AppDialog(QtGui.QWidget):
                 msg += __make_table_row("Version", "%s" % vers_str)
 
                 if sg_item.get("entity"):
-                    entity_str = "<b>%s</b> %s" % (sg_item.get("entity").get("type"),
-                                                   sg_item.get("entity").get("name"))
+                    display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk,
+                                                                          sg_item.get("entity").get("type"))
+                    entity_str = "<b>%s</b> %s" % (display_name, sg_item.get("entity").get("name"))
                     msg += __make_table_row("Link", entity_str)
 
                 # sort out the task label

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -650,8 +650,7 @@ class AppDialog(QtGui.QWidget):
                     desc_str = "No description entered."
 
                 msg = ""
-                display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk,
-                                                                      sg_data["type"])
+                display_name = shotgun_globals.get_type_display_name(sg_data["type"])
                 msg += __make_table_row("Name", "%s %s" % (display_name, sg_data.get("code")))
                 msg += __make_table_row("Status", status_name)
                 msg += __make_table_row("Description", desc_str)
@@ -710,8 +709,7 @@ class AppDialog(QtGui.QWidget):
                 msg += __make_table_row("Version", "%s" % vers_str)
 
                 if sg_item.get("entity"):
-                    display_name = sgtk.util.get_entity_type_display_name(sgtk.platform.current_engine().sgtk,
-                                                                          sg_item.get("entity").get("type"))
+                    display_name = shotgun_globals.get_type_display_name(sg_item.get("entity").get("type"))
                     entity_str = "<b>%s</b> %s" % (display_name, sg_item.get("entity").get("name"))
                     msg += __make_table_row("Link", entity_str)
 
@@ -1791,8 +1789,7 @@ class AppDialog(QtGui.QWidget):
 
                 else:
                     # lookup the display name for the entity type:
-                    tk = sgtk.platform.current_bundle().sgtk
-                    sg_type_display_name = sgtk.util.get_entity_type_display_name(tk, sg_type)
+                    sg_type_display_name = shotgun_globals.get_type_display_name(sg_type)
                     crumbs.append("<b>%s</b> %s" % (sg_type_display_name, name))
                 tmp_item = tmp_item.parent()
 


### PR DESCRIPTION
Currently the delegated widgets are using the entity type. We replaced this value with the entity display name.

![image](https://user-images.githubusercontent.com/2762494/71476748-a68bd580-27b4-11ea-9215-52fc35ed801c.png)
