### PR TITLE
Python 3 Maya hooks update

### DIFF
--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -15,10 +15,11 @@ Hook that loads defines all the available actions, broken down by publish type.
 import glob
 import os
 import re
-import pymel.core as pm
 import maya.cmds as cmds
 import maya.mel as mel
 import sgtk
+
+from tank_vendor import six
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -178,7 +179,7 @@ class MayaActions(HookBaseClass):
         # resolve path
         # toolkit uses utf-8 encoded strings internally and Maya API expects unicode
         # so convert the path to ensure filenames containing complex characters are supported
-        path = self.get_publish_path(sg_publish_data).decode("utf-8")
+        path = six.ensure_str(self.get_publish_path(sg_publish_data))
 
         if name == "reference":
             self._create_reference(path, sg_publish_data)
@@ -217,8 +218,10 @@ class MayaActions(HookBaseClass):
         )
         namespace = namespace.replace(" ", "_")
 
-        pm.system.createReference(
+        # Now create the reference object in Maya.
+        cmds.file(
             path,
+            reference=True,
             loadReferenceDepth="all",
             mergeNamespacesOnClash=False,
             namespace=namespace,


### PR DESCRIPTION
Updated to work with Python 3 and converted pymel use to the supported Autodesk APIs.