### PR TITLE
Python 3 fix for Photoshop

### DIFF
--- a/hooks/tk-photoshopcc_actions.py
+++ b/hooks/tk-photoshopcc_actions.py
@@ -16,6 +16,7 @@ import os
 
 import sgtk
 from sgtk.platform.qt import QtGui
+from tank_vendor import six
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -149,7 +150,7 @@ class PhotoshopActions(HookBaseClass):
         # resolve path
         # toolkit uses utf-8 encoded strings internally and the Photoshop API expects unicode
         # so convert the path to ensure filenames containing complex characters are supported
-        path = self.get_publish_path(sg_publish_data).decode("utf-8")
+        path = six.text_type(self.get_publish_path(sg_publish_data))
 
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)

--- a/hooks/tk-photoshopcc_actions.py
+++ b/hooks/tk-photoshopcc_actions.py
@@ -150,7 +150,7 @@ class PhotoshopActions(HookBaseClass):
         # resolve path
         # toolkit uses utf-8 encoded strings internally and the Photoshop API expects unicode
         # so convert the path to ensure filenames containing complex characters are supported
-        path = six.text_type(self.get_publish_path(sg_publish_data))
+        path = six.ensure_text(self.get_publish_path(sg_publish_data))
 
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)

--- a/python/tk_multi_loader/banner.py
+++ b/python/tk_multi_loader/banner.py
@@ -78,7 +78,7 @@ class Banner(QtGui.QLabel):
         """
         elapsed = (time.time() - self._show_time) * 1000
 
-        # Make sure we store any animations we create as a class variable to avoid it being garbage collected.
+        # Make sure we store any animations we create as a class instance variable to avoid it being garbage collected.
         # Not doing so will result in a warning when we try to clear the animation group.
 
         # We'll pause if required.

--- a/python/tk_multi_loader/banner.py
+++ b/python/tk_multi_loader/banner.py
@@ -78,19 +78,22 @@ class Banner(QtGui.QLabel):
         """
         elapsed = (time.time() - self._show_time) * 1000
 
+        # Make sure we store any animations we create as a class variable to avoid it being garbage collected.
+        # Not doing so will result in a warning when we try to clear the animation group.
+
         # We'll pause if required.
-        self._banner_animation.addPause(max(3000 - elapsed, 0))
+        self._anim_pause = self._banner_animation.addPause(max(3000 - elapsed, 0))
 
         # Compute the fully expanded and folded positions.
         expanded_pos = self._calc_expanded_pos()
         folded_pos = expanded_pos.translated(0, -self._HEIGHT)
 
         # Animate the banner sliding out of the dialog.
-        sliding_out = QtCore.QPropertyAnimation(self, b"geometry")
-        sliding_out.setDuration(250)
-        sliding_out.setStartValue(expanded_pos)
-        sliding_out.setEndValue(folded_pos)
-        self._banner_animation.addAnimation(sliding_out)
+        self._anim_sliding_out = QtCore.QPropertyAnimation(self, b"geometry")
+        self._anim_sliding_out.setDuration(250)
+        self._anim_sliding_out.setStartValue(expanded_pos)
+        self._anim_sliding_out.setEndValue(folded_pos)
+        self._banner_animation.addAnimation(self._anim_sliding_out)
 
         # Launch the sliding out!
         self._banner_animation.start()


### PR DESCRIPTION
Fixes the Photoshopcc hook so that it works in Python 3.

Also fixed a `QAnimationGroup::animationAt: index is out of bounds` warning that was being raised when showing the banner for the second time. This was caused by the animation objects getting garbage collected.