### PR TITLE
Display entity name instead entity type

### DIFF
--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -204,7 +204,9 @@ class SgPublishListDelegate(PublishDelegate):
 
             entity_link = sg_data.get("entity")
             if entity_link:
-                entity_link_type = shotgun_globals.get_type_display_name(entity_link["type"])
+                entity_link_type = shotgun_globals.get_type_display_name(
+                    entity_link["type"]
+                )
                 main_text += "%s <span style='color:#2C93E2'>%s</span>" % (
                     entity_link_type,
                     entity_link["name"],

--- a/python/tk_multi_loader/delegate_publish_list.py
+++ b/python/tk_multi_loader/delegate_publish_list.py
@@ -95,8 +95,12 @@ class SgPublishListDelegate(PublishDelegate):
             and "type" in field_value
         ):
             # intermediate node with entity link
+            field_value_type = shotgun_globals.get_type_display_name(
+                field_value["type"]
+            )
+
             main_text = "<b>%s</b> <b style='color:#2C93E2'>%s</b>" % (
-                field_value["type"],
+                field_value_type,
                 field_value["name"],
             )
 
@@ -110,9 +114,10 @@ class SgPublishListDelegate(PublishDelegate):
                 if isinstance(v, dict) and "name" in v and "type" in v:
                     # This is a link field
                     name = v["name"]
+                    v_type = shotgun_globals.get_type_display_name(v["type"])
                     if name:
                         formatted_values.append(name)
-                        formatted_types.add(v["type"])
+                        formatted_types.add(v_type)
                 else:
                     formatted_values.append(str(v))
 
@@ -199,8 +204,9 @@ class SgPublishListDelegate(PublishDelegate):
 
             entity_link = sg_data.get("entity")
             if entity_link:
+                entity_link_type = shotgun_globals.get_type_display_name(entity_link["type"])
                 main_text += "%s <span style='color:#2C93E2'>%s</span>" % (
-                    entity_link["type"],
+                    entity_link_type,
                     entity_link["name"],
                 )
 

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -99,7 +99,7 @@ class SgPublishThumbDelegate(PublishDelegate):
         ):
             # intermediate node with entity link
             header_text = field_value["name"]
-            details_text = field_value["type"]
+            details_text = shotgun_globals.get_type_display_name(field_value["type"])
 
         elif isinstance(field_value, list):
             # this is a list of some sort. Loop over all elements and extract a comma separated list.

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -224,7 +224,8 @@ class SgPublishThumbDelegate(PublishDelegate):
             if entity_link is None:
                 details_text = "Unlinked"
             else:
-                details_text = "%s %s" % (entity_link["type"], entity_link["name"])
+                entity_link_type = shotgun_globals.get_type_display_name(entity_link["type"])
+                details_text = "%s %s" % (entity_link_type, entity_link["name"])
 
         else:
             # std publish - render with a name and a publish type

--- a/python/tk_multi_loader/delegate_publish_thumb.py
+++ b/python/tk_multi_loader/delegate_publish_thumb.py
@@ -224,7 +224,9 @@ class SgPublishThumbDelegate(PublishDelegate):
             if entity_link is None:
                 details_text = "Unlinked"
             else:
-                entity_link_type = shotgun_globals.get_type_display_name(entity_link["type"])
+                entity_link_type = shotgun_globals.get_type_display_name(
+                    entity_link["type"]
+                )
                 details_text = "%s %s" % (entity_link_type, entity_link["name"])
 
         else:


### PR DESCRIPTION
This is a complement of a previous pull request to display the entity's name instead of the entity's type.

![image](https://user-images.githubusercontent.com/2762494/78028805-33e74480-7325-11ea-85e9-c0faee81deb3.png)

In the image "CustomEntity07" is not a proper name and can confuse users.