### PR TITLE
SG-34348 Fixed mutable keyword argument: Multiloader.open_publish

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ class MultiLoader(sgtk.platform.Application):
         """
         return True
 
-    def open_publish(self, title="Open Publish", action="Open", publish_types=[]):
+    def open_publish(self, title="Open Publish", action="Open", publish_types=None):
         """
         Display the loader UI in an open-file style where a publish can be selected and the
         artist can then click the action button.  This will then return the selected publish.
@@ -71,5 +71,6 @@ class MultiLoader(sgtk.platform.Application):
                                         contain a much more complete list of fields from the
                                         Shotgun PublishedFile entity
         """
+        publish_types = publish_types or []
         tk_multi_loader = self.import_module("tk_multi_loader")
         return tk_multi_loader.open_publish_browser(self, title, action, publish_types)


### PR DESCRIPTION
I've noticed a funny behaviour where the `publish_types` keywordsometimes doesn't take effect on the first time `Multiloader.open_publish()` is called.

It was probably from `Multiloader.open_publish()` being called somewhere else previously and having it's mutable kwarg polluted.

See also:
- https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
- https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html