### PR TITLE
SG-31007 Loader2 wrong tab/entity selected by default in task context

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
+
 import sgtk
 from sgtk import TankError
 from sgtk.platform.qt import QtCore, QtGui

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -937,14 +937,8 @@ class AppDialog(QtGui.QWidget):
         :returns: Model item object or None if not found.
         """
         if ctx.task:
-            return model.item_from_entity(
-                ctx.task["type"],
-                ctx.task["id"]
-            )
-        return model.item_from_entity(
-            ctx.entity["type"],
-            ctx.entity["id"]
-        )
+            return model.item_from_entity(ctx.task["type"], ctx.task["id"])
+        return model.item_from_entity(ctx.entity["type"], ctx.entity["id"])
 
     def _on_home_clicked(self):
         """
@@ -970,10 +964,7 @@ class AppDialog(QtGui.QWidget):
                 else:
                     # First check if there's a task associated with this
                     # context.If there is, let's check if it does match entity profile.
-                    if (
-                            ctx.task and
-                            preset.entity_type == ctx.task.get("type")
-                    ):
+                    if ctx.task and preset.entity_type == ctx.task.get("type"):
                         # found an at least partially matching entity profile.
                         found_preset = preset_index
 
@@ -990,10 +981,7 @@ class AppDialog(QtGui.QWidget):
                     # this avoids that the wrong tab gets selected.
                     # For example if we launch into a Task context, we expect the
                     # tab that matches with the Task entity profile to be selected.
-                    if (
-                            preset.entity_type == ctx.entity.get("type")
-                            and not ctx.task
-                    ):
+                    if preset.entity_type == ctx.entity.get("type") and not ctx.task:
                         # found an at least partially matching entity profile.
                         found_preset = preset_index
 

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -967,8 +967,10 @@ class AppDialog(QtGui.QWidget):
                     # For example if we launch into a Task context, we expect the
                     # tab that matches with the Task entity profile to be selected.
                     if (
-                            ctx.task and preset.entity_type == ctx.task.get("type") or
-                            preset.entity_type == ctx.entity.get("type") and not ctx.task
+                        ctx.task
+                        and preset.entity_type == ctx.task.get("type")
+                        or preset.entity_type == ctx.entity.get("type")
+                        and not ctx.task
                     ):
                         # found an at least partially matching entity profile.
                         found_preset = preset_index

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -926,6 +926,16 @@ class AppDialog(QtGui.QWidget):
         finally:
             self._history_navigation_mode = False
 
+    def _get_item_from_entity(self, ctx, model):
+        if ctx.task:
+            return model.item_from_entity(
+                ctx.task["type"],
+                ctx.task["id"]
+            )
+        return model.item_from_entity(
+            ctx.entity["type"],
+            ctx.entity["id"]
+        )
 
     def _on_home_clicked(self):
         """

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -936,9 +936,8 @@ class AppDialog(QtGui.QWidget):
 
         :returns: Model item object or None if not found.
         """
-        if ctx.task:
-            return model.item_from_entity(ctx.task["type"], ctx.task["id"])
-        return model.item_from_entity(ctx.entity["type"], ctx.entity["id"])
+        ctx_object = ctx.task if ctx.task else ctx.entity
+        return model.item_from_entity(ctx_object["type"], ctx_object["id"])
 
     def _on_home_clicked(self):
         """
@@ -962,26 +961,15 @@ class AppDialog(QtGui.QWidget):
                     found_hierarchy_preset = preset_index
                     break
                 else:
-                    # First check if there's a task associated with this
+                    # Check if there's a task associated with this
                     # context.If there is, let's check if it does match entity profile.
-                    if ctx.task and preset.entity_type == ctx.task.get("type"):
-                        # found an at least partially matching entity profile.
-                        found_preset = preset_index
-
-                        # now see if our context object also exists in the tree of this profile
-                        model = preset.model
-                        # retrieve the item
-                        item = self._get_item_from_entity(ctx, model)
-
-                        if item is not None:
-                            # find an absolute match! Break the search.
-                            found_item = item
-                            break
-
-                    # this avoids that the wrong tab gets selected.
+                    # this also avoids that the wrong tab gets selected.
                     # For example if we launch into a Task context, we expect the
                     # tab that matches with the Task entity profile to be selected.
-                    if preset.entity_type == ctx.entity.get("type") and not ctx.task:
+                    if (
+                            ctx.task and preset.entity_type == ctx.task.get("type") or
+                            preset.entity_type == ctx.entity.get("type") and not ctx.task
+                    ):
                         # found an at least partially matching entity profile.
                         found_preset = preset_index
 

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -927,6 +927,15 @@ class AppDialog(QtGui.QWidget):
             self._history_navigation_mode = False
 
     def _get_item_from_entity(self, ctx, model):
+        """
+        Retrieve the item object based on
+        entity type and entity id.
+
+        :param Sgtk Context ctx: Context object.
+        :param model: The SG model.
+
+        :returns: Model item object or None if not found.
+        """
         if ctx.task:
             return model.item_from_entity(
                 ctx.task["type"],
@@ -959,7 +968,8 @@ class AppDialog(QtGui.QWidget):
                     found_hierarchy_preset = preset_index
                     break
                 else:
-                    # First check if we're into a task context.
+                    # First check if there's a task associated with this
+                    # context.If there is, let's check if it does match entity profile.
                     if (
                             ctx.task and
                             preset.entity_type == ctx.task.get("type")
@@ -977,12 +987,11 @@ class AppDialog(QtGui.QWidget):
                             found_item = item
                             break
 
-                    # this avoids that the Shot tab gets opened when for example we
-                    # launch into a Task context, and we have a Shot entity.
-                    # In this scope we only want that the "Shot" or "Asset" tabs get
-                    # opened when there's no a related Task in the context.
+                    # this avoids that the wrong tab gets selected.
+                    # For example if we launch into a Task context, we expect the
+                    # tab that matches with the Task entity profile to be selected.
                     if (
-                            preset.entity_type == ctx.entity["type"]
+                            preset.entity_type == ctx.entity.get("type")
                             and not ctx.task
                     ):
                         # found an at least partially matching entity profile.


### PR DESCRIPTION
This PR fix the issue in which the wrong tab(first tab) in the Loader  app is opened when the Loader is launched in a task context. Now the tab related to the 'entity_type' specified in the tk-multi-loader2.yml is opened.