### PR TITLE
SHOT-4295: Do not allow items to be dragged around

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -110,6 +110,9 @@ class AppDialog(QtGui.QWidget):
         self.ui = Ui_Dialog()
         self.ui.setupUi(self)
 
+        # Do not allow items to be dragged and moved around.
+        self.ui.publish_view.setMovement(QtGui.QListView.Static)
+
         #################################################
         # maintain a list where we keep a reference to
         # all the dynamic UI we create. This is to make


### PR DESCRIPTION
* Currently file items in Loader can be dragged around (click + hold and move)
* Set movement to static so that items stay in place

This is under the assumption that items are not meant to be draggable. I could not find any evidence that this is the desired case.