### PR TITLE
SHOT-4297/SHOT-4294: Add config option to use legacy filter widget and fix show only types from config

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -24,6 +24,14 @@ configuration:
         default_value: "Loader"
         description: Name to appear on the title of the UI Dialog.
 
+    use_legacy_published_file_type_filter:
+        type: bool
+        default_value: true
+        description: Set to True to use the legacy Published File Type filtering component.
+                     This will show the filter widget in the bottom-left corner, but will
+                     hide the more extensive Filter menu (which includes filtering options for
+                     Published File Types). The legacy Published File Type filter widget
+                     cannot be used in combination with the Filter menu.
 
     # hooks
     actions_hook:

--- a/info.yml
+++ b/info.yml
@@ -26,7 +26,7 @@ configuration:
 
     use_legacy_published_file_type_filter:
         type: bool
-        default_value: true
+        default_value: false
         description: Set to True to use the legacy Published File Type filtering component.
                      This will show the filter widget in the bottom-left corner, but will
                      hide the more extensive Filter menu (which includes filtering options for

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -239,7 +239,7 @@ class AppDialog(QtGui.QWidget):
         )
         self._set_main_view_mode(main_view_mode)
 
-        # whenever the type list is checked, update the publish filters
+        # whenever the publish type model is updated, also update the publish filters
         self._publish_type_model.itemChanged.connect(
             self._apply_type_filters_on_publishes
         )
@@ -1048,7 +1048,11 @@ class AppDialog(QtGui.QWidget):
         """
         # go through and figure out which checkboxes are clicked and then
         # update the publish proxy model so that only items of that type
-        # is displayed
+        # is displayed. NOTE the published file type filter widget has been
+        # removed, so this will retrieve all published file types that are
+        # set in the config. This establishes the base view to only show
+        # files that correspond to the config setting. To filter by publish
+        # file types, use the Filter menu
         sg_type_ids = self._publish_type_model.get_selected_types()
         self._publish_proxy_model.set_filter_by_type_ids(sg_type_ids)
 

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -203,7 +203,9 @@ class AppDialog(QtGui.QWidget):
 
         #################################################
         # setup publish model
-        self._publish_model = SgLatestPublishModel(self, self._publish_type_model, self._task_manager)
+        self._publish_model = SgLatestPublishModel(
+            self, self._publish_type_model, self._task_manager
+        )
 
         self._publish_main_overlay = ShotgunModelOverlayWidget(
             self._publish_model, self.ui.publish_view

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -302,8 +302,7 @@ class SgLatestPublishModel(ShotgunModel):
             )
             type_id_aggregates[type_id] += 1
 
-        if self._publish_type_model:
-            self._publish_type_model.set_active_types(type_id_aggregates)
+        self._publish_type_model.set_active_types(type_id_aggregates)
 
         # and now trigger a refresh
         self._refresh_data()
@@ -491,9 +490,8 @@ class SgLatestPublishModel(ShotgunModel):
         # publish type model.
 
         if len(sg_data_list) == 0 and len(self._treeview_folder_items) == 0:
-            if self._publish_type_model:
-                # tell publish type setup that there is nothing to display
-                self._publish_type_model.set_active_types({})
+            # tell publish type setup that there is nothing to display
+            self._publish_type_model.set_active_types({})
             return []
 
         # and process sg publish data
@@ -579,9 +577,8 @@ class SgLatestPublishModel(ShotgunModel):
             type_id = second_pass_data["type_id"]
             type_id_aggregates[type_id] += 1
 
-        if self._publish_type_model:
-            # tell the type model to reshuffle and reformat itself
-            # based on the types contained in this search
-            self._publish_type_model.set_active_types(type_id_aggregates)
+        # tell the type model to reshuffle and reformat itself
+        # based on the types contained in this search
+        self._publish_type_model.set_active_types(type_id_aggregates)
 
         return new_sg_data

--- a/python/tk_multi_loader/proxymodel_latestpublish.py
+++ b/python/tk_multi_loader/proxymodel_latestpublish.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
-from sgtk.platform.qt import QtCore, QtGui
 from tank_vendor import six
 
 from .model_latestpublish import SgLatestPublishModel

--- a/python/tk_multi_loader/proxymodel_latestpublish.py
+++ b/python/tk_multi_loader/proxymodel_latestpublish.py
@@ -51,7 +51,10 @@ class SgLatestPublishProxyModel(FilterItemProxyModel):
         Specify which type ids the publish model should allow through
         """
 
-        if set(self._valid_type_ids or []) == set(type_ids or []) and self._show_folders == show_folders:
+        if (
+            set(self._valid_type_ids or []) == set(type_ids or [])
+            and self._show_folders == show_folders
+        ):
             return  # Nothing changed
 
         self._valid_type_ids = type_ids

--- a/python/tk_multi_loader/ui/dialog.py
+++ b/python/tk_multi_loader/ui/dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'C:\Users\qa\sg_envs\dv\tk\tk-multi-loader2\resources\dialog.ui'
 #
-# Created: Thu Feb 16 16:25:09 2023
+# Created: Fri Aug 18 11:07:38 2023
 #      by: pyside-uic 0.2.15 running on PySide 1.2.2
 #
 # WARNING! All changes made in this file will be lost!
@@ -119,9 +119,48 @@ class Ui_Dialog(object):
         self.entity_preset_tabs.setUsesScrollButtons(True)
         self.entity_preset_tabs.setObjectName("entity_preset_tabs")
         self.verticalLayout_2.addWidget(self.entity_preset_tabs)
+        self.label_4 = QtGui.QLabel(self.left_area_widget)
+        self.label_4.setAlignment(QtCore.Qt.AlignCenter)
+        self.label_4.setObjectName("label_4")
+        self.verticalLayout_2.addWidget(self.label_4)
+        self.publish_type_list = QtGui.QListView(self.left_area_widget)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Maximum)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.publish_type_list.sizePolicy().hasHeightForWidth())
+        self.publish_type_list.setSizePolicy(sizePolicy)
+        self.publish_type_list.setMinimumSize(QtCore.QSize(100, 100))
+        self.publish_type_list.setStyleSheet("QListView::item {\n"
+"            border-top: 1px dotted #888888;\n"
+"            padding: 5px;\n"
+"          }")
+        self.publish_type_list.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        self.publish_type_list.setProperty("showDropIndicator", False)
+        self.publish_type_list.setSelectionMode(QtGui.QAbstractItemView.NoSelection)
+        self.publish_type_list.setUniformItemSizes(True)
+        self.publish_type_list.setObjectName("publish_type_list")
+        self.verticalLayout_2.addWidget(self.publish_type_list)
         self.horizontalLayout_6 = QtGui.QHBoxLayout()
         self.horizontalLayout_6.setSpacing(2)
         self.horizontalLayout_6.setObjectName("horizontalLayout_6")
+        self.check_all = QtGui.QToolButton(self.left_area_widget)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.check_all.sizePolicy().hasHeightForWidth())
+        self.check_all.setSizePolicy(sizePolicy)
+        self.check_all.setMinimumSize(QtCore.QSize(60, 26))
+        self.check_all.setObjectName("check_all")
+        self.horizontalLayout_6.addWidget(self.check_all)
+        self.check_none = QtGui.QToolButton(self.left_area_widget)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.check_none.sizePolicy().hasHeightForWidth())
+        self.check_none.setSizePolicy(sizePolicy)
+        self.check_none.setMinimumSize(QtCore.QSize(75, 26))
+        self.check_none.setObjectName("check_none")
+        self.horizontalLayout_6.addWidget(self.check_none)
         self.label_3 = QtGui.QLabel(self.left_area_widget)
         self.label_3.setText("")
         self.label_3.setAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignTrailing|QtCore.Qt.AlignVCenter)
@@ -369,6 +408,11 @@ class Ui_Dialog(object):
         self.navigation_next.setAccessibleName(QtGui.QApplication.translate("Dialog", "navigation_next", None, QtGui.QApplication.UnicodeUTF8))
         self.entity_preset_tabs.setToolTip(QtGui.QApplication.translate("Dialog", "This area shows <i>ShotGrid objects</i> such as Shots or Assets, grouped into sections. ", None, QtGui.QApplication.UnicodeUTF8))
         self.entity_preset_tabs.setAccessibleName(QtGui.QApplication.translate("Dialog", "entity_preset_tabs", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_4.setText(QtGui.QApplication.translate("Dialog", "<small>Filter by Published File Type</small>", None, QtGui.QApplication.UnicodeUTF8))
+        self.publish_type_list.setToolTip(QtGui.QApplication.translate("Dialog", "This list shows all the relevant <i>publish types</i> for your current selection. By ticking and unticking items in this list, publishes in the main view will be shown or hidden. You can see a summary count next to each publish type, showing how many items of that sort are matching your current selection.", None, QtGui.QApplication.UnicodeUTF8))
+        self.publish_type_list.setAccessibleName(QtGui.QApplication.translate("Dialog", "publish_type_list", None, QtGui.QApplication.UnicodeUTF8))
+        self.check_all.setText(QtGui.QApplication.translate("Dialog", "Select All", None, QtGui.QApplication.UnicodeUTF8))
+        self.check_none.setText(QtGui.QApplication.translate("Dialog", "Select None", None, QtGui.QApplication.UnicodeUTF8))
         self.cog_button.setToolTip(QtGui.QApplication.translate("Dialog", "Tools and Settings", None, QtGui.QApplication.UnicodeUTF8))
         self.cog_button.setAccessibleName(QtGui.QApplication.translate("Dialog", "cog_button", None, QtGui.QApplication.UnicodeUTF8))
         self.entity_breadcrumbs.setToolTip(QtGui.QApplication.translate("Dialog", "This <i>breadcrumbs listing</i> shows your currently selected ShotGrid location.", None, QtGui.QApplication.UnicodeUTF8))

--- a/python/tk_multi_loader/ui/dialog.py
+++ b/python/tk_multi_loader/ui/dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'C:\Users\qa\sg_envs\dv\tk\tk-multi-loader2\resources\dialog.ui'
 #
-# Created: Fri Aug 18 11:07:38 2023
+# Created: Fri Aug 18 11:46:58 2023
 #      by: pyside-uic 0.2.15 running on PySide 1.2.2
 #
 # WARNING! All changes made in this file will be lost!
@@ -119,10 +119,10 @@ class Ui_Dialog(object):
         self.entity_preset_tabs.setUsesScrollButtons(True)
         self.entity_preset_tabs.setObjectName("entity_preset_tabs")
         self.verticalLayout_2.addWidget(self.entity_preset_tabs)
-        self.label_4 = QtGui.QLabel(self.left_area_widget)
-        self.label_4.setAlignment(QtCore.Qt.AlignCenter)
-        self.label_4.setObjectName("label_4")
-        self.verticalLayout_2.addWidget(self.label_4)
+        self.publish_type_filter_title = QtGui.QLabel(self.left_area_widget)
+        self.publish_type_filter_title.setAlignment(QtCore.Qt.AlignCenter)
+        self.publish_type_filter_title.setObjectName("publish_type_filter_title")
+        self.verticalLayout_2.addWidget(self.publish_type_filter_title)
         self.publish_type_list = QtGui.QListView(self.left_area_widget)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Maximum)
         sizePolicy.setHorizontalStretch(0)
@@ -408,7 +408,7 @@ class Ui_Dialog(object):
         self.navigation_next.setAccessibleName(QtGui.QApplication.translate("Dialog", "navigation_next", None, QtGui.QApplication.UnicodeUTF8))
         self.entity_preset_tabs.setToolTip(QtGui.QApplication.translate("Dialog", "This area shows <i>ShotGrid objects</i> such as Shots or Assets, grouped into sections. ", None, QtGui.QApplication.UnicodeUTF8))
         self.entity_preset_tabs.setAccessibleName(QtGui.QApplication.translate("Dialog", "entity_preset_tabs", None, QtGui.QApplication.UnicodeUTF8))
-        self.label_4.setText(QtGui.QApplication.translate("Dialog", "<small>Filter by Published File Type</small>", None, QtGui.QApplication.UnicodeUTF8))
+        self.publish_type_filter_title.setText(QtGui.QApplication.translate("Dialog", "<small>Filter by Published File Type</small>", None, QtGui.QApplication.UnicodeUTF8))
         self.publish_type_list.setToolTip(QtGui.QApplication.translate("Dialog", "This list shows all the relevant <i>publish types</i> for your current selection. By ticking and unticking items in this list, publishes in the main view will be shown or hidden. You can see a summary count next to each publish type, showing how many items of that sort are matching your current selection.", None, QtGui.QApplication.UnicodeUTF8))
         self.publish_type_list.setAccessibleName(QtGui.QApplication.translate("Dialog", "publish_type_list", None, QtGui.QApplication.UnicodeUTF8))
         self.check_all.setText(QtGui.QApplication.translate("Dialog", "Select All", None, QtGui.QApplication.UnicodeUTF8))

--- a/resources/dialog.ui
+++ b/resources/dialog.ui
@@ -211,7 +211,7 @@ background-image: url(:/res/right_arrow_pressed.png);
         </widget>
        </item>
        <item>
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="publish_type_filter_title">
          <property name="text">
            <string>&lt;small&gt;Filter by Published File Type&lt;/small&gt;</string>
          </property>

--- a/resources/dialog.ui
+++ b/resources/dialog.ui
@@ -211,10 +211,98 @@ background-image: url(:/res/right_arrow_pressed.png);
         </widget>
        </item>
        <item>
+         <widget class="QLabel" name="label_4">
+         <property name="text">
+           <string>&lt;small&gt;Filter by Published File Type&lt;/small&gt;</string>
+         </property>
+         <property name="alignment">
+           <set>Qt::AlignCenter</set>
+         </property>
+         </widget>
+       </item>
+       <item>
+         <widget class="QListView" name="publish_type_list">
+         <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+           </sizepolicy>
+         </property>
+         <property name="minimumSize">
+           <size>
+           <width>100</width>
+           <height>100</height>
+           </size>
+         </property>
+         <property name="toolTip">
+           <string>This list shows all the relevant &lt;i&gt;publish types&lt;/i&gt; for your current selection. By ticking and unticking items in this list, publishes in the main view will be shown or hidden. You can see a summary count next to each publish type, showing how many items of that sort are matching your current selection.</string>
+         </property>
+         <property name="accessibleName">
+           <string>publish_type_list</string>
+         </property>
+         <property name="styleSheet">
+           <string notr="true">QListView::item {
+            border-top: 1px dotted #888888;
+            padding: 5px;
+          }</string>
+         </property>
+         <property name="editTriggers">
+           <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+           <bool>false</bool>
+         </property>
+         <property name="selectionMode">
+           <enum>QAbstractItemView::NoSelection</enum>
+         </property>
+         <property name="uniformItemSizes">
+           <bool>true</bool>
+         </property>
+         </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_6">
          <property name="spacing">
           <number>2</number>
          </property>
+         <item>
+           <widget class="QToolButton" name="check_all">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+             <width>60</width>
+             <height>26</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Select All</string>
+            </property>
+           </widget>
+         </item>
+         <item>
+           <widget class="QToolButton" name="check_none">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+             <width>75</width>
+             <height>26</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Select None</string>
+            </property>
+           </widget>
+         </item>
          <item>
           <widget class="QLabel" name="label_3">
            <property name="text">


### PR DESCRIPTION
There are some minor differences between using the old Published File Type filter widget compared to the new filter menu. If users prefer the old way, they can turn that back on using the new config option. Note that the legacy filter widget cannot be used with the new Filter menu, it is one or the other due to synchronization issues when both filtering is shown.

This also resolves issue for SHOT-4294: when using the new filter menu, only show published file types that are defined via the config.

The code in this PR is almost all strictly adding back functionality from v1.22.1 - no new functionality.