### PR TITLE
SHOT-4292: Improve API

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,12 +78,19 @@ class MultiLoader(sgtk.platform.Application):
         tk_multi_loader = self.import_module("tk_multi_loader")
         return tk_multi_loader.open_publish_browser(self, title, action, publish_types)
 
-    def create_loader_manager(self):
+    def create_loader_manager(self, bundle=None):
         """
         Create and return a :class:`tk_multi_loader.LoaderManager` instance.
         See the :class:`tk_multi_loader.LoaderManager` docs for details on
         how it can be used to automate your loading workflows.
 
+        :param bundle: The bundle to use the loader manager with. If not
+                       specified, the current Loader App bundle will be used.
+                       Specifying a bundle is useful when you want to use the
+                       LoaderManager api to create actions for a different app
+                       and use the settings defined in that app's configuration.
+        :type bundle: :class:`sgtk.platform.TankBundle`
+
         :returns: A :class:`tk_multi_loader.LoaderManager` instance
         """
-        return self._manager_class(self)
+        return self._manager_class(bundle or self)

--- a/info.yml
+++ b/info.yml
@@ -56,7 +56,8 @@ configuration:
     action_mappings:
         type: dict
         description: Associates published file types with actions. The actions are all defined
-                     inside the actions hook.
+                     inside the actions hook. Use special key 'All' to define actions for all
+                     published file types.
         default_value: {}
         default_value_tk-3dsmax:
             3dsmax Scene: [import, reference]

--- a/python/tk_multi_loader/api/manager.py
+++ b/python/tk_multi_loader/api/manager.py
@@ -91,6 +91,8 @@ class LoaderManager(object):
 
         # check if we have logic configured to handle this publish type.
         mappings = self._bundle.get_setting("action_mappings")
+        if not mappings:
+            return []
         # returns a structure on the form
         # { "Maya Scene": ["reference", "import"] }
         actions = mappings.get(publish_type, [])
@@ -258,6 +260,8 @@ class LoaderManager(object):
 
         # check if we have logic configured to handle this publish type.
         mappings = self._bundle.get_setting("entity_mappings")
+        if not mappings:
+            return []
 
         # returns a structure on the form
         # { "Shot": ["reference", "import"] }
@@ -292,6 +296,8 @@ class LoaderManager(object):
         :return:: True if the current actions setup knows how to handle this.
         """
         mappings = self._bundle.get_setting("action_mappings")
+        if not mappings:
+            return False
 
         # returns a structure on the form
         # { "Maya Scene": ["reference", "import"] }

--- a/python/tk_multi_loader/api/manager.py
+++ b/python/tk_multi_loader/api/manager.py
@@ -96,7 +96,7 @@ class LoaderManager(object):
         # returns a structure on the form
         # { "Maya Scene": ["reference", "import"] }
         actions = mappings.get(publish_type, [])
-
+        actions.extend(mappings.get("All", []))
         if len(actions) == 0:
             return []
 
@@ -302,6 +302,7 @@ class LoaderManager(object):
         # returns a structure on the form
         # { "Maya Scene": ["reference", "import"] }
         my_mappings = mappings.get(publish_type, [])
+        my_mappings.extend(mappings.get("All", []))
 
         return len(my_mappings) > 0
 


### PR DESCRIPTION
* Allow passing a Tank bundle (e.g. App, Engine, Framework) to create the Loader Manager api, so that the Loader api can be used from other Toolkit apps and use that app's settings (instead of only the Loaders settings, this allows the loader api to generate and execute actions  defined by other apps)
* Allow defining key `All` in the config settings to add actions for all published file types (currently you have to define the action for each file type)

_Example usage in Breakdown2: https://github.com/shotgunsoftware/tk-multi-breakdown2/pull/77_
- _Breakdown2 uses the Loader api to create/execute actions, while the Breakdown2 App itself just needs to define the actions in its config setting_