### PR TITLE
Nuke supports mxf since a while

### DIFF
--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -278,6 +278,7 @@ class NukeActions(HookBaseClass):
             ".tiff",
             ".tif",
             ".mov",
+            ".mxf",
             ".mp4",
             ".psd",
             ".tga",


### PR DESCRIPTION
All currently supported Versions of Nuke support reading mxf files.