### PR TITLE
[SG-40343] Tooltip don't show up when hovering an action in the Loader app

### DIFF
--- a/python/tk_multi_loader/delegate_publish.py
+++ b/python/tk_multi_loader/delegate_publish.py
@@ -34,6 +34,7 @@ class PublishWidget(QtGui.QWidget):
 
         # set up action menu
         self._menu = QtGui.QMenu()
+        self._menu.setToolTipsVisible(True)
         self._actions = []
         self.ui.button.setMenu(self._menu)
         self.ui.button.setVisible(False)

--- a/python/tk_multi_loader/delegate_publish_history.py
+++ b/python/tk_multi_loader/delegate_publish_history.py
@@ -46,6 +46,7 @@ class PublishHistoryWidget(QtGui.QWidget):
 
         # set up action menu
         self._menu = QtGui.QMenu()
+        self._menu.setToolTipsVisible(True)
         self._actions = []
         self.ui.button.setMenu(self._menu)
         self.ui.button.setVisible(False)

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -134,6 +134,7 @@ class AppDialog(QtGui.QWidget):
         self._details_pane_visible = False
 
         self._details_action_menu = QtGui.QMenu()
+        self._details_action_menu.setToolTipsVisible(True)
         self.ui.detail_actions_btn.setMenu(self._details_action_menu)
 
         self.ui.info.clicked.connect(self._toggle_details_pane)
@@ -428,6 +429,7 @@ class AppDialog(QtGui.QWidget):
 
         # Build a menu with all the actions.
         menu = QtGui.QMenu(self)
+        menu.setToolTipsVisible(True)
         actions = self._action_manager.get_actions_for_publishes(
             self.selected_publishes, self._action_manager.UI_AREA_MAIN
         )


### PR DESCRIPTION
When hovering a menu action in the Loader app, no tooltip is displayed even if the action description as been set in configuration

Expected behavior: on action hovering, the action description should be displayed as tooltip