### PR TITLE
SG-42049: Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-multi-loader2?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=73&branchName=master)
 [![codecov](https://codecov.io/gh/shotgunsoftware/tk-multi-loader2/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-multi-loader2)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 
 ## Documentation
 This repository is a part of the Flow Production Tracking Toolkit.


### PR DESCRIPTION
Removes deprecated HoundCI badge from README.

Related SG-42049 PRs:
- shotgunsoftware/tk-aftereffects#63
- shotgunsoftware/tk-core#1084
- shotgunsoftware/tk-framework-desktopclient#36
- shotgunsoftware/tk-framework-qtwidgets#181
- shotgunsoftware/tk-framework-shotgunutils#177
- shotgunsoftware/tk-framework-widget#31
- shotgunsoftware/tk-multi-about#36
- shotgunsoftware/tk-multi-breakdown#45
- shotgunsoftware/tk-multi-demo#48
- shotgunsoftware/tk-multi-launchapp#111
- shotgunsoftware/tk-multi-loader2#135
- shotgunsoftware/tk-multi-publish2#211
- shotgunsoftware/tk-multi-pythonconsole#44
- shotgunsoftware/tk-multi-reviewsubmission#51
- shotgunsoftware/tk-multi-screeningroom#26
- shotgunsoftware/tk-multi-snapshot#50
- shotgunsoftware/tk-multi-workfiles2#170
- shotgunsoftware/tk-shell#38