### PR TITLE
SG-43677 Fix hooks to support multiple keyword arguments

### DIFF
--- a/hooks/tk-3dsmaxplus_actions.py
+++ b/hooks/tk-3dsmaxplus_actions.py
@@ -24,7 +24,7 @@ class MaxActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -101,7 +101,7 @@ class MaxActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -132,7 +132,7 @@ class MaxActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -31,7 +31,7 @@ class DesktopActions(HookBaseClass):
         sg_publish_data: dict,
         actions: list,
         ui_area: str,
-        am_base_obj: Any = None,
+        **kwargs,
     ) -> list:
         """
         Return a list of action instances for a particular publish.
@@ -77,67 +77,76 @@ class DesktopActions(HookBaseClass):
 
         action_instances = []
 
-        if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
-            version_number = sg_publish_data.get("version_number")
+        enable_flowam = app.get_setting("enable_flowam", False)
+        if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+            if not am_base_obj:
+                raise Exception(
+                    "FlowAM is enabled but no Asset Management base object was passed to the action hook. "
+                    "FlowAM specific actions will not be generated."
+                )
+
+            if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
+                version_number = sg_publish_data.get("version_number")
+
+                if (
+                    version_number is not None
+                    and version_number != am_base_obj.DRAFT_VERSION_IDENTIFIER
+                ):
+                    action_instances.append(
+                        {
+                            "name": "download",
+                            "params": "Download 'params'",
+                            "caption": "Download",
+                            "description": "Downloads the published file to a user specified location.",
+                        }
+                    )
+
+            if "publish" in actions:
+                # Show publish action only for published files (not drafts)
+                # Drafts (version == -1) are not supported in generic workflow
+                version_number = sg_publish_data.get("version_number")
+
+                if version_number is not None and version_number >= 0:
+                    action_instances.append(
+                        {
+                            "name": "publish",
+                            "params": "Publish 'params'",
+                            "caption": "Publish",
+                            "description": "Publish a new revision of this generic asset.",
+                        }
+                    )
+
+            if "create_generic_asset" in actions:
+                action_instances.append(
+                    {
+                        "name": "create_generic_asset",
+                        "params": "Create Generic Asset 'params'",
+                        "caption": "Create Generic Asset",
+                        "description": "Executes Create Generic Asset.",
+                    }
+                )
 
             if (
-                version_number is not None
-                and version_number != am_base_obj.DRAFT_VERSION_IDENTIFIER
+                "reference_copy_link" in actions
+                and sg_publish_data.get(
+                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+                > am_base_obj.DRAFT_VERSION_IDENTIFIER
             ):
                 action_instances.append(
                     {
-                        "name": "download",
-                        "params": "Download 'params'",
-                        "caption": "Download",
-                        "description": "Downloads the published file to a user specified location.",
+                        "name": "reference_copy_link",
+                        "params": None,
+                        "caption": "Copy Reference Link",
+                        "description": "This will copy the reference as a string to the clipboard",
+                        "multi_select": False,
                     }
                 )
-
-        if "publish" in actions:
-            # Show publish action only for published files (not drafts)
-            # Drafts (version == -1) are not supported in generic workflow
-            version_number = sg_publish_data.get("version_number")
-
-            if version_number is not None and version_number >= 0:
-                action_instances.append(
-                    {
-                        "name": "publish",
-                        "params": "Publish 'params'",
-                        "caption": "Publish",
-                        "description": "Publish a new revision of this generic asset.",
-                    }
-                )
-
-        if "create_generic_asset" in actions:
-            action_instances.append(
-                {
-                    "name": "create_generic_asset",
-                    "params": "Create Generic Asset 'params'",
-                    "caption": "Create Generic Asset",
-                    "description": "Executes Create Generic Asset.",
-                }
-            )
-
-        if (
-            "reference_copy_link" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            > am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "reference_copy_link",
-                    "params": None,
-                    "caption": "Copy Reference Link",
-                    "description": "This will copy the reference as a string to the clipboard",
-                    "multi_select": False,
-                }
-            )
 
         return action_instances
 
-    def execute_multiple_actions(self, actions: list, am_base_obj: Any = None) -> None:
+    def execute_multiple_actions(self, actions: list, **kwargs) -> None:
         """
         Executes the specified action on a list of items.
 
@@ -170,14 +179,14 @@ class DesktopActions(HookBaseClass):
             name = single_action["name"]
             sg_publish_data = single_action["sg_publish_data"]
             params = single_action["params"]
-            self.execute_action(name, params, sg_publish_data, am_base_obj)
+            self.execute_action(name, params, sg_publish_data, **kwargs)
 
     def execute_action(
         self,
         name: str,
         params: Any,
         sg_publish_data: dict,
-        am_base_obj: Any = None,
+        **kwargs,
     ) -> None:
         """
         Print out all actions. The data sent to this be method will
@@ -193,6 +202,7 @@ class DesktopActions(HookBaseClass):
             "Execute action called for action %s. "
             "Parameters: %s. Publish Data: %s" % (name, params, sg_publish_data)
         )
+        am_base_obj = kwargs.get("am_base_obj")
 
         if name == "create_generic_asset":
             # Right click a task the left panel

--- a/hooks/tk-flame_actions.py
+++ b/hooks/tk-flame_actions.py
@@ -44,7 +44,7 @@ class FlameActionError(Exception):
 class FlameActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -136,7 +136,7 @@ class FlameActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -167,7 +167,7 @@ class FlameActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -25,7 +25,7 @@ class HoudiniActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area, am_base_obj=None):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -102,95 +102,104 @@ class HoudiniActions(HookBaseClass):
         # -----------------------
         # FlowAM specific actions
         # -----------------------
-        if "open" in actions and sg_publish_data.get("type") == "PublishedFile":
+        enable_flowam = app.get_setting("enable_flowam", False)
+        if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+            if not am_base_obj:
+                raise Exception(
+                    "FlowAM is enabled but no Asset Management base object was passed to the action hook. "
+                    "FlowAM specific actions will not be generated."
+                )
+
+            if "open" in actions and sg_publish_data.get("type") == "PublishedFile":
+                if (
+                    am_base_obj._is_local_draft(sg_publish_data)
+                    or sg_publish_data.get(
+                        "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                    )
+                    > am_base_obj.DRAFT_VERSION_IDENTIFIER
+                ):
+                    action_instances.append(
+                        {
+                            "name": "open",
+                            "params": None,
+                            "caption": "Open",
+                            "description": "This will open the item into the current scene.",
+                            "multi_select": False,
+                        }
+                    )
+
+            if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
+                version_number = sg_publish_data.get("version_number")
+
+                if (
+                    version_number is not None
+                    and version_number != am_base_obj.DRAFT_VERSION_IDENTIFIER
+                ):
+                    action_instances.append(
+                        {
+                            "name": "download",
+                            "params": "Download 'params'",
+                            "caption": "Download",
+                            "description": "Downloads the published file to a user specified location.",
+                        }
+                    )
+
+            if "discard_draft" in actions:
+                draft_id = sg_publish_data.get("sg_flow_revision_id")
+
+                if am_base_obj._is_local_draft(
+                    sg_publish_data
+                ) and am_base_obj._is_new_asset(draft_id):
+                    action_instances.append(
+                        {
+                            "name": "discard_draft",
+                            "params": None,
+                            "caption": "Discard Draft",
+                            "description": "This will discard the local draft for this publish.",
+                        }
+                    )
+
             if (
-                am_base_obj._is_local_draft(sg_publish_data)
-                or sg_publish_data.get(
+                "reference_copy_link" in actions
+                and sg_publish_data.get(
                     "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
                 )
-                > am_base_obj.DRAFT_VERSION_IDENTIFIER
+                != am_base_obj.DRAFT_VERSION_IDENTIFIER
             ):
                 action_instances.append(
                     {
-                        "name": "open",
+                        "name": "reference_copy_link",
                         "params": None,
-                        "caption": "Open",
-                        "description": "This will open the item into the current scene.",
+                        "caption": "Copy Reference Link",
+                        "description": "This will copy the reference as a string to the clipboard",
                         "multi_select": False,
                     }
                 )
 
-        if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
-            version_number = sg_publish_data.get("version_number")
-
-            if (
-                version_number is not None
-                and version_number != am_base_obj.DRAFT_VERSION_IDENTIFIER
-            ):
+            if "build_new_scene" in actions:
                 action_instances.append(
                     {
-                        "name": "download",
-                        "params": "Download 'params'",
-                        "caption": "Download",
-                        "description": "Downloads the published file to a user specified location.",
-                    }
-                )
-
-        if "discard_draft" in actions:
-            draft_id = sg_publish_data.get("sg_flow_revision_id")
-
-            if am_base_obj._is_local_draft(
-                sg_publish_data
-            ) and am_base_obj._is_new_asset(draft_id):
-                action_instances.append(
-                    {
-                        "name": "discard_draft",
+                        "name": "build_new_scene",
                         "params": None,
-                        "caption": "Discard Draft",
-                        "description": "This will discard the local draft for this publish.",
+                        "caption": "Build New Scene",
+                        "description": "This will create a new scene in the current project.",
                     }
                 )
 
-        if (
-            "reference_copy_link" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            != am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "reference_copy_link",
-                    "params": None,
-                    "caption": "Copy Reference Link",
-                    "description": "This will copy the reference as a string to the clipboard",
-                    "multi_select": False,
-                }
-            )
-
-        if "build_new_scene" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_scene",
-                    "params": None,
-                    "caption": "Build New Scene",
-                    "description": "This will create a new scene in the current project.",
-                }
-            )
-
-        if "build_new_template" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_template",
-                    "params": None,
-                    "caption": "Build New Template",
-                    "description": "This will create a new template scene in the current project.",
-                }
-            )
+            if "build_new_template" in actions:
+                action_instances.append(
+                    {
+                        "name": "build_new_template",
+                        "params": None,
+                        "caption": "Build New Template",
+                        "description": "This will create a new template scene in the current project.",
+                    }
+                )
 
         return action_instances
 
-    def execute_multiple_actions(self, actions, am_base_obj=None):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -219,9 +228,9 @@ class HoudiniActions(HookBaseClass):
             name = single_action["name"]
             sg_publish_data = single_action["sg_publish_data"]
             params = single_action["params"]
-            self.execute_action(name, params, sg_publish_data, am_base_obj)
+            self.execute_action(name, params, sg_publish_data, **kwargs)
 
-    def execute_action(self, name, params, sg_publish_data, am_base_obj=None):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.
@@ -242,6 +251,8 @@ class HoudiniActions(HookBaseClass):
         # -----------------------
         enable_flowam = app.get_setting("enable_flowam", False)
         if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+
             if name == "open":
                 am_base_obj._do_open(sg_publish_data)
 

--- a/hooks/tk-mari_actions.py
+++ b/hooks/tk-mari_actions.py
@@ -25,7 +25,7 @@ class MariActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -108,7 +108,7 @@ class MariActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -139,7 +139,7 @@ class MariActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -28,7 +28,7 @@ class MayaActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area, am_base_obj=None):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -129,116 +129,125 @@ class MayaActions(HookBaseClass):
         # -----------------------
         # FlowAM specific actions
         # -----------------------
-        if (
-            "open" in actions
-            and sg_publish_data.get("type") == "PublishedFile"
-            and (
-                am_base_obj._is_local_draft(sg_publish_data)
-                or sg_publish_data.get(
-                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+        enable_flowam = app.get_setting("enable_flowam", False)
+        if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+            if not am_base_obj:
+                raise Exception(
+                    "FlowAM is enabled but no Asset Management base object was passed to the action hook. "
+                    "FlowAM specific actions will not be generated."
                 )
-                > am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-        ):
-            action_instances.append(
-                {
-                    "name": "open",
-                    "params": None,
-                    "caption": "Open",
-                    "description": "This will open the item into the current scene.",
-                    "multi_select": False,
-                }
-            )
 
-        if (
-            "download" in actions
-            and sg_publish_data.get("type") == "PublishedFile"
-            and (
-                sg_publish_data.get("version_number") is not None
-                and sg_publish_data.get("version_number")
-                != am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-        ):
-            action_instances.append(
-                {
-                    "name": "download",
-                    "params": "Download 'params'",
-                    "caption": "Download",
-                    "description": "Downloads the published file to a user specified location.",
-                }
-            )
-
-        if "discard_draft" in actions:
-            draft_id = sg_publish_data.get("sg_flow_revision_id")
-
-            if am_base_obj._is_local_draft(
-                sg_publish_data
-            ) and am_base_obj._is_new_asset(draft_id):
+            if (
+                "open" in actions
+                and sg_publish_data.get("type") == "PublishedFile"
+                and (
+                    am_base_obj._is_local_draft(sg_publish_data)
+                    or sg_publish_data.get(
+                        "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                    )
+                    > am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+            ):
                 action_instances.append(
                     {
-                        "name": "discard_draft",
+                        "name": "open",
                         "params": None,
-                        "caption": "Discard Draft",
-                        "description": "This will discard the local draft for this publish.",
+                        "caption": "Open",
+                        "description": "This will open the item into the current scene.",
+                        "multi_select": False,
                     }
                 )
 
-        if (
-            "reference_am" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            != am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "reference_am",
-                    "params": None,
-                    "caption": "Reference",
-                    "description": "This will load the item into the current scene as a reference",
-                }
-            )
+            if (
+                "download" in actions
+                and sg_publish_data.get("type") == "PublishedFile"
+                and (
+                    sg_publish_data.get("version_number") is not None
+                    and sg_publish_data.get("version_number")
+                    != am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+            ):
+                action_instances.append(
+                    {
+                        "name": "download",
+                        "params": "Download 'params'",
+                        "caption": "Download",
+                        "description": "Downloads the published file to a user specified location.",
+                    }
+                )
 
-        if (
-            "reference_copy_link" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            != am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "reference_copy_link",
-                    "params": None,
-                    "caption": "Copy Reference Link",
-                    "description": "This will copy the reference as a string to the clipboard",
-                    "multi_select": False,
-                }
-            )
+            if "discard_draft" in actions:
+                draft_id = sg_publish_data.get("sg_flow_revision_id")
 
-        if "build_new_scene" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_scene",
-                    "params": None,
-                    "caption": "Build New Scene",
-                    "description": "This will create a new scene in the current project.",
-                }
-            )
+                if am_base_obj._is_local_draft(
+                    sg_publish_data
+                ) and am_base_obj._is_new_asset(draft_id):
+                    action_instances.append(
+                        {
+                            "name": "discard_draft",
+                            "params": None,
+                            "caption": "Discard Draft",
+                            "description": "This will discard the local draft for this publish.",
+                        }
+                    )
 
-        if "build_new_template" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_template",
-                    "params": None,
-                    "caption": "Build New Template",
-                    "description": "This will create a new template scene in the current project.",
-                }
-            )
+            if (
+                "reference_am" in actions
+                and sg_publish_data.get(
+                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+                != am_base_obj.DRAFT_VERSION_IDENTIFIER
+            ):
+                action_instances.append(
+                    {
+                        "name": "reference_am",
+                        "params": None,
+                        "caption": "Reference",
+                        "description": "This will load the item into the current scene as a reference",
+                    }
+                )
+
+            if (
+                "reference_copy_link" in actions
+                and sg_publish_data.get(
+                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+                != am_base_obj.DRAFT_VERSION_IDENTIFIER
+            ):
+                action_instances.append(
+                    {
+                        "name": "reference_copy_link",
+                        "params": None,
+                        "caption": "Copy Reference Link",
+                        "description": "This will copy the reference as a string to the clipboard",
+                        "multi_select": False,
+                    }
+                )
+
+            if "build_new_scene" in actions:
+                action_instances.append(
+                    {
+                        "name": "build_new_scene",
+                        "params": None,
+                        "caption": "Build New Scene",
+                        "description": "This will create a new scene in the current project.",
+                    }
+                )
+
+            if "build_new_template" in actions:
+                action_instances.append(
+                    {
+                        "name": "build_new_template",
+                        "params": None,
+                        "caption": "Build New Template",
+                        "description": "This will create a new template scene in the current project.",
+                    }
+                )
 
         return action_instances
 
-    def execute_multiple_actions(self, actions, am_base_obj=None):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -267,9 +276,9 @@ class MayaActions(HookBaseClass):
             name = single_action["name"]
             sg_publish_data = single_action["sg_publish_data"]
             params = single_action["params"]
-            self.execute_action(name, params, sg_publish_data, am_base_obj)
+            self.execute_action(name, params, sg_publish_data, **kwargs)
 
-    def execute_action(self, name, params, sg_publish_data, am_base_obj=None):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.
@@ -290,6 +299,8 @@ class MayaActions(HookBaseClass):
         # -----------------------
         enable_flowam = app.get_setting("enable_flowam", False)
         if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+
             if name == "reference_am":
                 am_base_obj._create_reference_am(sg_publish_data)
 

--- a/hooks/tk-motionbuilder_actions.py
+++ b/hooks/tk-motionbuilder_actions.py
@@ -24,7 +24,7 @@ class MotionbuilderActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -81,7 +81,7 @@ class MotionbuilderActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -112,7 +112,7 @@ class MotionbuilderActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -27,7 +27,7 @@ class NukeActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area, am_base_obj=None):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -115,88 +115,99 @@ class NukeActions(HookBaseClass):
         # -----------------------
         # FlowAM specific actions
         # -----------------------
-        if "build_new_script" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_script",
-                    "params": None,
-                    "caption": "Build New Script",
-                    "description": "This will create a new script in the current project.",
-                }
-            )
-        if "build_new_template" in actions:
-            action_instances.append(
-                {
-                    "name": "build_new_template",
-                    "params": None,
-                    "caption": "Build New Template",
-                    "description": "This will create a new template script in the current project.",
-                }
-            )
-        if "open" in actions and sg_publish_data.get("type") == "PublishedFile":
-            # Show open action for:
-            # 1. Local drafts (version_number == -1 and is_local_draft)
-            # 2. Published revisions (version_number > -1)
-            if (
-                am_base_obj._is_local_draft(sg_publish_data)
-                or sg_publish_data.get(
-                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+        enable_flowam = app.get_setting("enable_flowam", False)
+        if enable_flowam:
+            am_base_obj = kwargs.get("am_base_obj")
+            if not am_base_obj:
+                raise Exception(
+                    "FlowAM is enabled but no Asset Management base object was passed to the action hook. "
+                    "FlowAM specific actions will not be generated."
                 )
-                > am_base_obj.DRAFT_VERSION_IDENTIFIER
+
+            if "build_new_script" in actions:
+                action_instances.append(
+                    {
+                        "name": "build_new_script",
+                        "params": None,
+                        "caption": "Build New Script",
+                        "description": "This will create a new script in the current project.",
+                    }
+                )
+            if "build_new_template" in actions:
+                action_instances.append(
+                    {
+                        "name": "build_new_template",
+                        "params": None,
+                        "caption": "Build New Template",
+                        "description": "This will create a new template script in the current project.",
+                    }
+                )
+            if "open" in actions and sg_publish_data.get("type") == "PublishedFile":
+                # Show open action for:
+                # 1. Local drafts (version_number == -1 and is_local_draft)
+                # 2. Published revisions (version_number > -1)
+                if (
+                    am_base_obj._is_local_draft(sg_publish_data)
+                    or sg_publish_data.get(
+                        "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                    )
+                    > am_base_obj.DRAFT_VERSION_IDENTIFIER
+                ):
+                    action_instances.append(
+                        {
+                            "name": "open",
+                            "params": None,
+                            "caption": "Open",
+                            "description": "This will open the item into the current script.",
+                        }
+                    )
+
+            if "discard_draft" in actions and am_base_obj._is_local_draft(
+                sg_publish_data
             ):
                 action_instances.append(
                     {
-                        "name": "open",
+                        "name": "discard_draft",
                         "params": None,
-                        "caption": "Open",
-                        "description": "This will open the item into the current script.",
+                        "caption": "Discard Draft",
+                        "description": "This will discard the local draft.",
+                    }
+                )
+            if (
+                "reference_copy_link" in actions
+                and sg_publish_data.get(
+                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+                != am_base_obj.DRAFT_VERSION_IDENTIFIER
+            ):
+                action_instances.append(
+                    {
+                        "name": "reference_copy_link",
+                        "params": None,
+                        "caption": "Copy Reference Link",
+                        "description": "This will copy the reference link as a string to the clipboard.",
+                        "multi_select": False,
+                    }
+                )
+            if (
+                "create_read_node" in actions
+                and sg_publish_data.get(
+                    "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
+                )
+                != am_base_obj.DRAFT_VERSION_IDENTIFIER
+            ):
+                action_instances.append(
+                    {
+                        "name": "create_read_node",
+                        "params": None,
+                        "caption": "Create Read Node",
+                        "description": "This will load the item into the current script as a new Read node.",
                     }
                 )
 
-        if "discard_draft" in actions and am_base_obj._is_local_draft(sg_publish_data):
-            action_instances.append(
-                {
-                    "name": "discard_draft",
-                    "params": None,
-                    "caption": "Discard Draft",
-                    "description": "This will discard the local draft.",
-                }
-            )
-        if (
-            "reference_copy_link" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            != am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "reference_copy_link",
-                    "params": None,
-                    "caption": "Copy Reference Link",
-                    "description": "This will copy the reference link as a string to the clipboard.",
-                    "multi_select": False,
-                }
-            )
-        if (
-            "create_read_node" in actions
-            and sg_publish_data.get(
-                "version_number", am_base_obj.DRAFT_VERSION_IDENTIFIER
-            )
-            != am_base_obj.DRAFT_VERSION_IDENTIFIER
-        ):
-            action_instances.append(
-                {
-                    "name": "create_read_node",
-                    "params": None,
-                    "caption": "Create Read Node",
-                    "description": "This will load the item into the current script as a new Read node.",
-                }
-            )
-
         return action_instances
 
-    def execute_multiple_actions(self, actions, am_base_obj=None):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -225,9 +236,9 @@ class NukeActions(HookBaseClass):
             name = single_action["name"]
             sg_publish_data = single_action["sg_publish_data"]
             params = single_action["params"]
-            self.execute_action(name, params, sg_publish_data, am_base_obj)
+            self.execute_action(name, params, sg_publish_data, **kwargs)
 
-    def execute_action(self, name, params, sg_publish_data, am_base_obj=None):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.
@@ -247,8 +258,10 @@ class NukeActions(HookBaseClass):
         # -----------------------
         # FlowAM specific actions
         # -----------------------
-        enable_flowam = app.get_setting("enable_flowam", False)
-        if enable_flowam:
+        use_medm_data = app.get_setting("use_medm_data", False)
+        if use_medm_data:
+            am_base_obj = kwargs.get("am_base_obj")
+
             if name == "build_new_script":
                 am_base_obj._build_new_scene(sg_publish_data)
 

--- a/hooks/tk-photoshop_actions.py
+++ b/hooks/tk-photoshop_actions.py
@@ -34,7 +34,7 @@ class PhotoshopActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -101,7 +101,7 @@ class PhotoshopActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -132,7 +132,7 @@ class PhotoshopActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-photoshopcc_actions.py
+++ b/hooks/tk-photoshopcc_actions.py
@@ -29,7 +29,7 @@ class PhotoshopActions(HookBaseClass):
     ##############################################################################################################
     # public interface - to be overridden by deriving classes
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Returns a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -96,7 +96,7 @@ class PhotoshopActions(HookBaseClass):
 
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -129,7 +129,7 @@ class PhotoshopActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Execute a given action. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.

--- a/hooks/tk-shell_actions.py
+++ b/hooks/tk-shell_actions.py
@@ -23,7 +23,7 @@ class ShellActions(HookBaseClass):
     Stub implementation of the shell actions, used for testing.
     """
 
-    def generate_actions(self, sg_publish_data, actions, ui_area):
+    def generate_actions(self, sg_publish_data, actions, ui_area, **kwargs):
         """
         Return a list of action instances for a particular publish.
         This method is called each time a user clicks a publish somewhere in the UI.
@@ -111,7 +111,7 @@ class ShellActions(HookBaseClass):
             )
         return action_instances
 
-    def execute_multiple_actions(self, actions):
+    def execute_multiple_actions(self, actions, **kwargs):
         """
         Executes the specified action on a list of items.
 
@@ -146,7 +146,7 @@ class ShellActions(HookBaseClass):
             params = single_action["params"]
             self.execute_action(name, params, sg_publish_data)
 
-    def execute_action(self, name, params, sg_publish_data):
+    def execute_action(self, name, params, sg_publish_data, **kwargs):
         """
         Print out all actions. The data sent to this be method will
         represent one of the actions enumerated by the generate_actions method.


### PR DESCRIPTION
Base branch: #137 

DCCs that are not supported with FlowAM integration crashes their hooks due to unexpected arguments. This PRs addresses this issue by just adding `**kwargs` and silently ignoring them when not needed.