### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -158,6 +158,7 @@ description: "Locate published files and reference them into your scene."
 requires_shotgun_version:
 requires_core_version: "v0.19.1"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # The documentation url for this item
 documentation_url: "https://help.autodesk.com/view/SGDEV/ENU/?guid=SG_Supervisor_Artist_sa_integrations_sa_integrations_user_guide_html#the-loader"

--- a/python/tk_multi_loader/banner.py
+++ b/python/tk_multi_loader/banner.py
@@ -28,7 +28,7 @@ class Banner(QtGui.QLabel):
         """
         :param parent: Parent widget.
         """
-        super(Banner, self).__init__(parent)
+        super().__init__(parent)
 
         # Sets the style sheet for the widget.
         self.setStyleSheet(

--- a/python/tk_multi_loader/model_publishtype.py
+++ b/python/tk_multi_loader/model_publishtype.py
@@ -220,7 +220,7 @@ class SgPublishTypeModel(ShotgunModel):
         """
         Clears any caches on disk, then refreshes the data.
         """
-        super(SgPublishTypeModel, self).hard_refresh()
+        super().hard_refresh()
         self._load_external_data()
 
     ############################################################################################

--- a/python/tk_multi_loader/proxymodel_latestpublish.py
+++ b/python/tk_multi_loader/proxymodel_latestpublish.py
@@ -26,7 +26,7 @@ class SgLatestPublishProxyModel(FilterItemProxyModel):
     filter_changed = QtCore.Signal()
 
     def __init__(self, parent):
-        super(SgLatestPublishProxyModel, self).__init__(parent)
+        super().__init__(parent)
         self._valid_type_ids = None
         self._show_folders = True
         self._search_filter = ""
@@ -73,9 +73,7 @@ class SgLatestPublishProxyModel(FilterItemProxyModel):
         model and see if we should let it pass or not.
         """
 
-        base_model_accepts = super(SgLatestPublishProxyModel, self).filterAcceptsRow(
-            source_row, source_parent_idx
-        )
+        base_model_accepts = super().filterAcceptsRow(source_row, source_parent_idx)
         if not base_model_accepts:
             return False
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ class AppTestBase(TankTestBase):
         os.environ["LOADER2_API_TEST"] = "api_test"
 
         # First call the parent TankTestBase constructor to set up the tests base
-        super(AppTestBase, self).setUp()
+        super().setUp()
         self.setup_fixtures()
 
         # get useful tank setting
@@ -96,7 +96,7 @@ class AppTestBase(TankTestBase):
             cur_engine.destroy()
 
         # important to call base class so it can clean up memory
-        super(AppTestBase, self).tearDown()
+        super().tearDown()
 
 
 class TestApi(AppTestBase):
@@ -111,7 +111,7 @@ class TestApi(AppTestBase):
         Set up before any tests are executed.
         """
 
-        super(TestApi, self).setUp()
+        super().setUp()
 
         # setup published file types
         self.published_file_type1 = {


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` calls across 4 files (7 call sites)

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)