### PR TITLE
Remove config dependency for entity mapping

### DIFF
--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -208,6 +208,41 @@ class DesktopActions(HookBaseClass):
         elif name == "download":
             flowam_actions._download_asset_revision(sg_publish_data)
 
+    def action_mappings(self) -> dict:
+        """
+        Returns the action mappings for the loader app.
+
+        :returns: Dictionary of action mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "Maya Workfile": ["download", "reference_copy_link"],
+                "Nuke Workfile": ["download", "reference_copy_link"],
+                "Houdini Workfile": ["download", "reference_copy_link"],
+                "All": ["download", "publish", "reference_copy_link"],
+            }
+
+        return {}
+
+    def entity_mappings(self) -> dict:
+        """
+        Returns the entity mappings for the loader app.
+
+        :returns: Dictionary of entity mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "Project": ["create_generic_asset"],
+                "Task": ["create_generic_asset"],
+            }
+
+        return {}
+
+    ##############################################################################################################
+    # helper methods which can be subclassed in custom hooks to fine tune the behavior of things
+
     def _launch_publisher(self, action_name: str, sg_publish_data: dict) -> None:
         """
         Launches the publisher app in the context of the specified entity (task or project).

--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -217,10 +217,11 @@ class DesktopActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
+                "All": ["download"],
                 "Maya Workfile": ["download", "reference_copy_link"],
                 "Nuke Workfile": ["download", "reference_copy_link"],
                 "Houdini Workfile": ["download", "reference_copy_link"],
-                "All": ["download", "publish", "reference_copy_link"],
+                "Generic Workfile": ["download", "reference_copy_link", "publish"],
             }
 
         return {}

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -281,6 +281,36 @@ class HoudiniActions(HookBaseClass):
         if name == "file_cop":
             self._file_cop(path, sg_publish_data)
 
+    def action_mappings(self) -> dict:
+        """
+        Returns the action mappings for the loader app.
+
+        :returns: Dictionary of action mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "All": ["reference_copy_link"],
+                "Houdini Workfile": ["open", "discard_draft"],
+            }
+
+        return {}
+
+    def entity_mappings(self) -> dict:
+        """
+        Returns the entity mappings for the loader app.
+
+        :returns: Dictionary of entity mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "Project": ["create_generic_asset"],
+                "Task": ["create_generic_asset"],
+            }
+
+        return {}
+
     ##############################################################################################################
     # helper methods which can be subclassed in custom hooks to fine tune the behaviour of things
 

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -291,7 +291,7 @@ class HoudiniActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Houdini Workfile": ["open", "discard_draft"],
+                "Houdini Workfile": ["open", "reference_copy_link", "discard_draft"],
                 "Template": ["open", "download"],
             }
 

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -292,6 +292,7 @@ class HoudiniActions(HookBaseClass):
             return {
                 "All": ["reference_copy_link", "download"],
                 "Houdini Workfile": ["open", "discard_draft"],
+                "Template": ["open", "download"],
             }
 
         return {}

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -290,7 +290,7 @@ class HoudiniActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
-                "All": ["reference_copy_link"],
+                "All": ["reference_copy_link", "download"],
                 "Houdini Workfile": ["open", "discard_draft"],
             }
 
@@ -305,8 +305,8 @@ class HoudiniActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
-                "Project": ["create_generic_asset"],
-                "Task": ["create_generic_asset"],
+                "Project": ["build_new_template"],
+                "Task": ["build_new_scene"],
             }
 
         return {}

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -337,6 +337,38 @@ class MayaActions(HookBaseClass):
         if name == "image_plane":
             self._create_image_plane(path, sg_publish_data)
 
+    def action_mappings(self) -> dict:
+        """
+        Returns the action mappings for the loader app.
+
+        :returns: Dictionary of action mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "All": ["reference_copy_link", "download"],
+                "Maya Workfile": ["reference_am", "open", "discard_draft"],
+                "Alembic": ["reference_am"],
+                "Template": ["open"],
+            }
+
+        return {}
+
+    def entity_mappings(self) -> dict:
+        """
+        Returns the entity mappings for the loader app.
+
+        :returns: Dictionary of entity mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "Project": ["create_generic_asset"],
+                "Task": ["create_generic_asset"],
+            }
+
+        return {}
+
     ##############################################################################################################
     # helper methods which can be subclassed in custom hooks to fine tune the behaviour of things
 

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -347,7 +347,13 @@ class MayaActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Maya Workfile": ["reference_am", "open", "discard_draft"],
+                "Maya Workfile": [
+                    "reference_am",
+                    "open",
+                    "discard_draft",
+                    "reference_copy_link",
+                    "download",
+                ],
                 "Template": ["open", "download"],
             }
 

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -348,7 +348,6 @@ class MayaActions(HookBaseClass):
             return {
                 "All": ["reference_copy_link", "download"],
                 "Maya Workfile": ["reference_am", "open", "discard_draft"],
-                "Alembic": ["reference_am"],
                 "Template": ["open"],
             }
 
@@ -363,8 +362,8 @@ class MayaActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
-                "Project": ["create_generic_asset"],
-                "Task": ["create_generic_asset"],
+                "Project": ["build_new_template"],
+                "Task": ["build_new_scene"],
             }
 
         return {}

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -348,7 +348,7 @@ class MayaActions(HookBaseClass):
             return {
                 "All": ["reference_copy_link", "download"],
                 "Maya Workfile": ["reference_am", "open", "discard_draft"],
-                "Template": ["open"],
+                "Template": ["open", "download"],
             }
 
         return {}

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -307,7 +307,7 @@ class NukeActions(HookBaseClass):
                 "Nuke Workfile": ["open", "discard_draft"],
                 "Generic Workfile": ["reference_copy_link", "create_read_node"],
                 "File Sequence": ["reference_copy_link", "create_read_node"],
-                "Template": ["open"],
+                "Template": ["open", "download"],
                 "Alembic Cache": [],
                 "Flame Render": ["create_read_node"],
                 "Flame Quicktime": ["create_read_node"],

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -294,6 +294,48 @@ class NukeActions(HookBaseClass):
         if name == "clip_import":
             self._import_clip(path, sg_publish_data)
 
+    def action_mappings(self) -> dict:
+        """
+        Returns the action mappings for the loader app.
+
+        :returns: Dictionary of action mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "All": ["reference_copy_link"],
+                "Nuke Workfile": ["open", "discard_draft"],
+                "Generic Workfile": ["reference_copy_link", "create_read_node"],
+                "File Sequence": ["reference_copy_link", "create_read_node"],
+                "Template": ["open"],
+                "Alembic Cache": [],
+                "Flame Render": ["create_read_node"],
+                "Flame Quicktime": ["create_read_node"],
+                "Image": ["create_read_node"],
+                "Movie": ["create_read_node"],
+                "NukeStudio Project": ["open_project"],
+                "Photoshop Image": ["create_read_node"],
+                "Rendered Image": ["create_read_node"],
+                "Texture": ["create_read_node"],
+            }
+
+        return {}
+
+    def entity_mappings(self) -> dict:
+        """
+        Returns the entity mappings for the loader app.
+
+        :returns: Dictionary of entity mappings.
+        """
+        app = self.parent
+        if app.flowam_available:
+            return {
+                "Project": ["create_generic_asset"],
+                "Task": ["create_generic_asset"],
+            }
+
+        return {}
+
     ##############################################################################################################
     # helper methods which can be subclassed in custom hooks to fine tune the behavior of things
 

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -304,7 +304,12 @@ class NukeActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Nuke Workfile": ["open", "discard_draft", "reference_copy_link", "download"],
+                "Nuke Workfile": [
+                    "open",
+                    "discard_draft",
+                    "reference_copy_link",
+                    "download",
+                ],
                 "Generic Workfile": ["reference_copy_link", "create_read_node"],
                 "File Sequence": ["reference_copy_link", "create_read_node"],
                 "Template": ["open", "download"],

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -304,7 +304,7 @@ class NukeActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Nuke Workfile": ["open", "discard_draft"],
+                "Nuke Workfile": ["open", "discard_draft", "reference_copy_link", "download"],
                 "Generic Workfile": ["reference_copy_link", "create_read_node"],
                 "File Sequence": ["reference_copy_link", "create_read_node"],
                 "Template": ["open", "download"],

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -303,7 +303,7 @@ class NukeActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
-                "All": ["reference_copy_link"],
+                "All": ["reference_copy_link", "download"],
                 "Nuke Workfile": ["open", "discard_draft"],
                 "Generic Workfile": ["reference_copy_link", "create_read_node"],
                 "File Sequence": ["reference_copy_link", "create_read_node"],
@@ -330,8 +330,8 @@ class NukeActions(HookBaseClass):
         app = self.parent
         if app.flowam_available:
             return {
-                "Project": ["create_generic_asset"],
-                "Task": ["create_generic_asset"],
+                "Project": ["build_new_template"],
+                "Task": ["build_new_scene"],
             }
 
         return {}

--- a/python/tk_multi_loader/api/manager.py
+++ b/python/tk_multi_loader/api/manager.py
@@ -96,6 +96,13 @@ class LoaderManager(object):
 
         # check if we have logic configured to handle this publish type.
         mappings = self._bundle.get_setting("action_mappings")
+        try:
+            mappings = {
+                **mappings,
+                **self._bundle.execute_hook_method("actions_hook", "action_mappings"),
+            }
+        except TankError:
+            pass
         if not mappings:
             return []
         # returns a structure on the form
@@ -285,6 +292,13 @@ class LoaderManager(object):
 
         # check if we have logic configured to handle this publish type.
         mappings = self._bundle.get_setting("entity_mappings")
+        try:
+            mappings = {
+                **mappings,
+                **self._bundle.execute_hook_method("actions_hook", "entity_mappings"),
+            }
+        except TankError:
+            pass
         if not mappings:
             return []
 


### PR DESCRIPTION
Base PR #137 

We used to have multiple mappings per DCC in the testing config. For now, let's move them to the engine hooks and don't expose them to the yml settings.