### PR TITLE
SG-44525 Fix tk-nuke action: create read node

### DIFF
--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -275,7 +275,7 @@ class NukeActions(HookBaseClass):
                 flowam_actions._create_reference_copy_link(sg_publish_data)
 
             if name == "create_read_node":
-                flowam_actions._create_reference(sg_publish_data)
+                flowam_actions._create_reference_am(sg_publish_data)
 
             return
 


### PR DESCRIPTION
This pull request updates the behavior of the `create_read_node` action in `tk-nuke_actions.py` to use a new function for creating references. This change likely reflects a refactor or an improvement in how references are created for this action.

- **Refactoring and Function Replacement:**
  - Changed the function call for the `create_read_node` action from `flowam_actions._create_reference` to `flowam_actions._create_reference_am` to use the updated or more appropriate reference creation logic.