### PR TITLE
Add download action to Hodini Workfile type

### DIFF
--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -291,7 +291,7 @@ class HoudiniActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Houdini Workfile": ["open", "reference_copy_link", "discard_draft"],
+                "Houdini Workfile": ["open", "reference_copy_link", "discard_draft", "download"],
                 "Template": ["open", "download"],
             }
 

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -291,7 +291,12 @@ class HoudiniActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "All": ["reference_copy_link", "download"],
-                "Houdini Workfile": ["open", "reference_copy_link", "discard_draft", "download"],
+                "Houdini Workfile": [
+                    "open",
+                    "reference_copy_link",
+                    "discard_draft",
+                    "download",
+                ],
                 "Template": ["open", "download"],
             }
 


### PR DESCRIPTION
This pull request makes a small update to the action mappings for Houdini workfiles. The "download" action is now available for "Houdini Workfile" items, making it consistent with other item types.

- Added the "download" action to the list of available actions for "Houdini Workfile" in the `action_mappings` method (`hooks/tk-houdini_actions.py`).