### PR TITLE
SG-44439 Hide filter widgets on flowam mode as well

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -383,6 +383,11 @@ class AppDialog(QtGui.QWidget):
             # Disable filter menu for Flow Asset Management mode - it expects ShotgunModel data
             self._filter_menu = None
             self.ui.filter_menu_btn.hide()
+            # Also hide the legacy filter widgets
+            self.ui.publish_type_list.hide()
+            self.ui.publish_type_filter_title.hide()
+            self.ui.check_all.hide()
+            self.ui.check_none.hide()
         else:
             # Hide the legacy filter widgets
             self.ui.publish_type_list.hide()


### PR DESCRIPTION
Hide the following widget as it's not intended to be part of the loader in the first place.

<img width="781" height="672" alt="image" src="https://github.com/user-attachments/assets/c640e7c5-380e-4578-ba7a-0ae73cc2ebce" />
