### PR TITLE
SG-44218 Fix contextual menu on entities

### DIFF
--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -135,6 +135,11 @@ class AppDialog(QtGui.QWidget):
         # the GC happy.
         self._dynamic_widgets = []
 
+        # Flag used to prevent re-entrant calls to _popup_menu.
+        # A spurious context menu event can be generated when a modal
+        # dialog opened from a menu action closes (e.g. Create New template).
+        self._popup_menu_active = False
+
         # maintain a special flag so that we can switch profile
         # tabs without triggering events
         self._disable_tab_event_handler = False
@@ -1914,18 +1919,38 @@ class AppDialog(QtGui.QWidget):
 
         :param position: The position where the menu should be displayed.
         """
+        # Guard against re-entrant calls. When an action opens a modal dialog,
+        # closing that dialog can cause Qt to deliver a spurious context menu
+        # event (e.g. a replayed WM_CONTEXTMENU on Windows). Without this guard
+        # the menu would re-appear as soon as the dialog is dismissed.
+        if self._popup_menu_active:
+            return
+
         view = self.sender()
 
         # Do not show the context menu when right-clicking on an empty area.
         if not view.indexAt(position).isValid():
             return
 
-        menu = QtGui.QMenu(view)
+        self._popup_menu_active = True
+        try:
+            menu = QtGui.QMenu(view)
 
-        for action in view.actions():
-            menu.addAction(action)
+            for action in view.actions():
+                menu.addAction(action)
 
-        menu.exec_(view.viewport().mapToGlobal(position))
+            menu.exec_(view.viewport().mapToGlobal(position))
+        finally:
+            # Defer the flag reset so the guard stays active for one additional
+            # event-loop iteration. This discards any spurious ContextMenu event
+            # that was queued during the menu or dialog execution (e.g. an async
+            # file-open triggered by an action that eventually generates a
+            # WM_CONTEXTMENU message for the parent window).
+            QtCore.QTimer.singleShot(0, self._clear_popup_menu_flag)
+
+    def _clear_popup_menu_flag(self):
+        """Reset the popup menu active flag after pending events are processed."""
+        self._popup_menu_active = False
 
     def _set_contextual_menu(
         self, sg_data: dict, field_value: Any, view: Any, model: Any

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1915,6 +1915,11 @@ class AppDialog(QtGui.QWidget):
         :param position: The position where the menu should be displayed.
         """
         view = self.sender()
+
+        # Do not show the context menu when right-clicking on an empty area.
+        if not view.indexAt(position).isValid():
+            return
+
         menu = QtGui.QMenu(view)
 
         for action in view.actions():
@@ -2020,6 +2025,10 @@ class AppDialog(QtGui.QWidget):
         # ---------------------------------------------------------------
 
         view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        try:
+            view.customContextMenuRequested.disconnect(self._popup_menu)
+        except RuntimeError:
+            pass
         view.customContextMenuRequested.connect(self._popup_menu)
 
     def _get_entity_root(self, root):

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -109,6 +109,7 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
             entity_fields = {"__all__": default_fields}
 
         # Load a hierarchy that leads to entities linked via "PublishedFile.entity".
+        self._root_entity = root_entity
         self.load_data(
             "PublishedFile.entity", root=root_entity, entity_fields=entity_fields
         )
@@ -121,6 +122,6 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
 
         self.load_data(
             self._seed_entity_field,
-            entity=self._root_entity,
+            root=self._root_entity,
             entity_fields=self._entity_fields,
         )


### PR DESCRIPTION
This pull request improves the user experience and stability of the context menu in the `tk_multi_loader` dialog by ensuring the menu only appears when appropriate and preventing duplicate signal connections.

**Context menu behavior improvements:**

* The `_popup_menu` method now checks if the user right-clicked on a valid item before displaying the context menu, preventing the menu from appearing when right-clicking on empty areas.

**Signal connection management:**

* Before connecting the `customContextMenuRequested` signal to `_popup_menu`, the code now attempts to disconnect any previous connections, avoiding duplicate connections and potential errors.