### PR TITLE
SG-44442 Fix published files name search for flowam

### DIFF
--- a/python/tk_multi_loader/proxymodel_latestpublish.py
+++ b/python/tk_multi_loader/proxymodel_latestpublish.py
@@ -77,27 +77,26 @@ class SgLatestPublishProxyModel(FilterItemProxyModel):
         if not base_model_accepts:
             return False
 
-        if self._valid_type_ids is None:
-            # accept all!
-            return True
-
         model = self.sourceModel()
 
         current_item = model.invisibleRootItem().child(
             source_row
         )  # assume non-tree structure
 
-        # first analyze any search filtering
+        # Apply search filtering first, regardless of type filter state.
         if self._search_filter:
-
-            # there is a search filter entered
             field_data = shotgun_model.get_sanitized_data(
                 current_item, SgLatestPublishModel.SEARCHABLE_NAME
             )
-
+            if not field_data:
+                return False
             if self._search_filter.lower() not in field_data.lower():
                 # item text is not matching search filter
                 return False
+
+        if self._valid_type_ids is None:
+            # No type filter active - accept all items.
+            return True
 
         # now check if folders should be shown
         is_folder = current_item.data(SgLatestPublishModel.IS_FOLDER_ROLE)


### PR DESCRIPTION
This pull request refines the filtering logic in `proxymodel_latestpublish.py` to ensure that search filtering is always applied before type filtering. This change improves the accuracy and predictability of the filter behavior, especially when both search and type filters are used.

Filtering logic improvements:

* The search filter is now applied before checking for type filters, ensuring that search results are always respected regardless of the type filter state.
* If the search filter is set but the item's searchable field is missing or empty, the item is now correctly excluded from the results.
* The code clarifies that when no type filter is active (`_valid_type_ids` is `None`), all items passing the search filter are accepted.