### PR TITLE
SG-43959 UI/UX for VariantSet component selector

### DIFF
--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -336,7 +336,7 @@ class NukeActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "Project": ["build_new_template"],
-                "Task": ["build_new_scene"],
+                "Task": ["build_new_script"],
             }
 
         return {}

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -135,6 +135,11 @@ class AppDialog(QtGui.QWidget):
         # the GC happy.
         self._dynamic_widgets = []
 
+        # Flag used to prevent re-entrant calls to _popup_menu.
+        # A spurious context menu event can be generated when a modal
+        # dialog opened from a menu action closes (e.g. Create New template).
+        self._popup_menu_active = False
+
         # maintain a special flag so that we can switch profile
         # tabs without triggering events
         self._disable_tab_event_handler = False
@@ -1914,13 +1919,38 @@ class AppDialog(QtGui.QWidget):
 
         :param position: The position where the menu should be displayed.
         """
+        # Guard against re-entrant calls. When an action opens a modal dialog,
+        # closing that dialog can cause Qt to deliver a spurious context menu
+        # event (e.g. a replayed WM_CONTEXTMENU on Windows). Without this guard
+        # the menu would re-appear as soon as the dialog is dismissed.
+        if self._popup_menu_active:
+            return
+
         view = self.sender()
-        menu = QtGui.QMenu(view)
 
-        for action in view.actions():
-            menu.addAction(action)
+        # Do not show the context menu when right-clicking on an empty area.
+        if not view.indexAt(position).isValid():
+            return
 
-        menu.exec_(view.viewport().mapToGlobal(position))
+        self._popup_menu_active = True
+        try:
+            menu = QtGui.QMenu(view)
+
+            for action in view.actions():
+                menu.addAction(action)
+
+            menu.exec_(view.viewport().mapToGlobal(position))
+        finally:
+            # Defer the flag reset so the guard stays active for one additional
+            # event-loop iteration. This discards any spurious ContextMenu event
+            # that was queued during the menu or dialog execution (e.g. an async
+            # file-open triggered by an action that eventually generates a
+            # WM_CONTEXTMENU message for the parent window).
+            QtCore.QTimer.singleShot(0, self._clear_popup_menu_flag)
+
+    def _clear_popup_menu_flag(self):
+        """Reset the popup menu active flag after pending events are processed."""
+        self._popup_menu_active = False
 
     def _set_contextual_menu(
         self, sg_data: dict, field_value: Any, view: Any, model: Any
@@ -2020,6 +2050,10 @@ class AppDialog(QtGui.QWidget):
         # ---------------------------------------------------------------
 
         view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        try:
+            view.customContextMenuRequested.disconnect(self._popup_menu)
+        except RuntimeError:
+            pass
         view.customContextMenuRequested.connect(self._popup_menu)
 
     def _get_entity_root(self, root):

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -383,6 +383,11 @@ class AppDialog(QtGui.QWidget):
             # Disable filter menu for Flow Asset Management mode - it expects ShotgunModel data
             self._filter_menu = None
             self.ui.filter_menu_btn.hide()
+            # Also hide the legacy filter widgets
+            self.ui.publish_type_list.hide()
+            self.ui.publish_type_filter_title.hide()
+            self.ui.check_all.hide()
+            self.ui.check_none.hide()
         else:
             # Hide the legacy filter widgets
             self.ui.publish_type_list.hide()

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1168,8 +1168,10 @@ class AppDialog(QtGui.QWidget):
                     # When the user picks a different variant, refresh the
                     # actions menu for that variant.
                     selector.selection_changed.connect(
-                        lambda sn, vn, aid, vsd=variant_sg_dicts: (
-                            self._update_actions_for_variant(aid, vsd)
+                        lambda _set_name, _variant_name, asset_id, variant_set_dicts=variant_sg_dicts: (
+                            self._update_actions_for_variant(
+                                asset_id, variant_set_dicts
+                            )
                         )
                     )
 

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -93,6 +93,11 @@ class AppDialog(QtGui.QWidget):
         # FlowAM tree view - only created when FlowAM is enabled
         self._medm_tree_view = None
 
+        # Variant selector widget shown in the details panel when a FlowAM
+        # variant container asset is selected.  Created on first use and
+        # re-populated on every selection change.
+        self._medm_variant_selector = None
+
         # The loader app can be invoked from other applications with a custom
         # action manager as a File Open-like dialog. For these managers, we won't
         # be using the banner system.
@@ -176,6 +181,12 @@ class AppDialog(QtGui.QWidget):
             # FlowAM history model for FlowAM publish items
             self._medm_history_model = MedmPublishHistoryModel(
                 self, self._task_manager, self._medm_cache, self._medm_thumbnail_service
+            )
+
+            # When a history item's thumbnail arrives asynchronously, re-apply
+            # it to details_image if that item is currently selected.
+            self._medm_history_model.dataChanged.connect(
+                self._on_history_item_data_changed
             )
 
         self._publish_history_model_overlay = ShotgunModelOverlayWidget(
@@ -1130,26 +1141,67 @@ class AppDialog(QtGui.QWidget):
 
                 sg_item = item.get_sg_data()
 
-                required_fields = ["name", "type", "version_number"]
-                optional_fields = [
-                    "entity",
-                    "task",
-                    "version.Version.sg_status_list",
-                ]
-                all_fields = list(
-                    dict.fromkeys(required_fields + optional_fields + configured_fields)
+                # ----------------------------------------------------------
+                # FlowAM variant container: show variant selectors and route
+                # the actions menu through the currently selected variant.
+                # ----------------------------------------------------------
+                variant_sets = sg_item.get("_variant_sets") if sg_item else None
+                variant_sg_dicts = (
+                    sg_item.get("_variant_sg_dicts", {}) if sg_item else {}
                 )
 
-                actions = self._action_manager.get_actions_for_publish(
-                    sg_item, self._action_manager.UI_AREA_DETAILS
-                )
-                if len(actions) == 0:
-                    self.ui.detail_actions_btn.setVisible(False)
+                # Tear down any previous variant selector.
+                if self._medm_variant_selector is not None:
+                    self._medm_variant_selector.setParent(None)
+                    self._medm_variant_selector.deleteLater()
+                    self._medm_variant_selector = None
+
+                if variant_sets and self.flowam_available:
+                    from .flowam.variant_selector_widget import VariantSelectorWidget
+
+                    selector = VariantSelectorWidget(
+                        variant_sets, self.ui.details_widget
+                    )
+                    self._medm_variant_selector = selector
+                    self.ui.details_widget.layout().addWidget(selector)
+
+                    # When the user picks a different variant, refresh the
+                    # actions menu for that variant.
+                    selector.selection_changed.connect(
+                        lambda sn, vn, aid, vsd=variant_sg_dicts: (
+                            self._update_actions_for_variant(aid, vsd)
+                        )
+                    )
+
+                    # Clear stale history before seeding with the first variant.
+                    self._publish_history_model.clear()
+                    if self._medm_history_model is not None:
+                        self._medm_history_model.clear()
+                    self._update_history_view_height()
+
+                    # Seed the actions menu and history with the first option of
+                    # the first set so the panel is immediately usable.
+                    first_set_variants = next(iter(variant_sets.values()), [])
+                    if first_set_variants:
+                        _first_asset_id = first_set_variants[0][1]
+                        self._update_actions_for_variant(
+                            _first_asset_id, variant_sg_dicts
+                        )
                 else:
-                    self._details_action_menu.clear()
-                    for a in actions:
-                        self._dynamic_widgets.append(a)
-                        self._details_action_menu.addAction(a)
+                    # Normal (non-variant) publish: restore history view and
+                    # build the actions menu from the item's own sg_data.
+                    self.ui.history_view.setEnabled(True)
+
+                    actions = self._action_manager.get_actions_for_publish(
+                        sg_item, self._action_manager.UI_AREA_DETAILS
+                    )
+                    if len(actions) == 0:
+                        self.ui.detail_actions_btn.setVisible(False)
+                    else:
+                        self._details_action_menu.clear()
+                        for a in actions:
+                            self._dynamic_widgets.append(a)
+                            self._details_action_menu.addAction(a)
 
                 if sg_item.get("version"):
                     sg_url = sgtk.platform.current_bundle().shotgun.base_url
@@ -1160,6 +1212,16 @@ class AppDialog(QtGui.QWidget):
                     self._current_version_detail_playback_url = url
                 else:
                     self._current_version_detail_playback_url = None
+
+                required_fields = ["name", "type", "version_number"]
+                optional_fields = [
+                    "entity",
+                    "task",
+                    "version.Version.sg_status_list",
+                ]
+                all_fields = list(
+                    dict.fromkeys(required_fields + optional_fields + configured_fields)
+                )
 
                 msg = ""
                 type_str = shotgun_model.get_sanitized_data(
@@ -1190,21 +1252,158 @@ class AppDialog(QtGui.QWidget):
                 sg_data = item.get_sg_data()
 
                 # Route to the correct history model.
+                # FlowAM variant containers have already cleared history above;
+                # skip re-loading it here.
                 # FlowAM data is identified by _medm_asset or _medm_draft keys.
-                if self._medm_history_model is not None and (
-                    sg_data.get("_medm_asset") is not None
-                    or sg_data.get("_medm_draft") is not None
-                ):
-                    self._publish_history_proxy.setSourceModel(self._medm_history_model)
-                    self._medm_history_model.load_data(sg_data)
-                else:
-                    self._publish_history_proxy.setSourceModel(
-                        self._publish_history_model
-                    )
-                    self._publish_history_model.load_data(sg_data)
-                self._update_history_view_height()
+                if not variant_sets:
+                    if self._medm_history_model is not None and (
+                        sg_data.get("_medm_asset") is not None
+                        or sg_data.get("_medm_draft") is not None
+                    ):
+                        self._publish_history_proxy.setSourceModel(
+                            self._medm_history_model
+                        )
+                        self._medm_history_model.load_data(sg_data)
+                    else:
+                        self._publish_history_proxy.setSourceModel(
+                            self._publish_history_model
+                        )
+                        self._publish_history_model.load_data(sg_data)
+                    self._update_history_view_height()
 
             self.ui.details_header.updateGeometry()
+
+    def _on_history_item_data_changed(
+        self,
+        top_left: "QtCore.QModelIndex",
+        bottom_right: "QtCore.QModelIndex",
+        roles: list,
+    ) -> None:
+        """Re-apply the details thumbnail when an async thumbnail load completes
+        for the currently selected item in the history view."""
+        sel_indexes = self.ui.history_view.selectionModel().selectedIndexes()
+        if not sel_indexes:
+            return
+
+        proxy_index = sel_indexes[0]
+        source_index = self._publish_history_proxy.mapToSource(proxy_index)
+        if not source_index.isValid():
+            return
+
+        # Only act when the changed region covers the selected row and the
+        # active source model is the FlowAM history model.
+        if self._publish_history_proxy.sourceModel() is not self._medm_history_model:
+            return
+        if not (top_left.row() <= source_index.row() <= bottom_right.row()):
+            return
+
+        item = self._medm_history_model.itemFromIndex(source_index)
+        if item is None:
+            return
+
+        publish_thumb = item.data(SgPublishHistoryModel.PUBLISH_THUMB_ROLE)
+        if (
+            publish_thumb
+            and isinstance(publish_thumb, QtGui.QPixmap)
+            and not publish_thumb.isNull()
+        ):
+            target_size = self.ui.details_image.size()
+            scaled = publish_thumb.scaled(
+                target_size,
+                QtCore.Qt.KeepAspectRatio,
+                QtCore.Qt.SmoothTransformation,
+            )
+            self.ui.details_image.setPixmap(scaled)
+            self.ui.details_image.setScaledContents(False)
+
+    def _on_publish_item_data_changed(
+        self,
+        top_left: "QtCore.QModelIndex",
+        bottom_right: "QtCore.QModelIndex",
+        roles: list,
+    ) -> None:
+        """Re-apply the details thumbnail when the selected center-panel
+        card's thumbnail arrives asynchronously."""
+        # Only act when the FlowAM publish model is the active source.
+        # Firing while the SG model is active would read the wrong context
+        # and potentially overwrite the details_image with a stale icon.
+        if self._publish_proxy_model.sourceModel() is not self._medm_publish_model:
+            return
+
+        sel_indexes = self.ui.publish_view.selectionModel().selectedIndexes()
+        if not sel_indexes:
+            return
+
+        proxy_index = sel_indexes[0]
+        source_index = self._publish_proxy_model.mapToSource(proxy_index)
+        if not source_index.isValid():
+            return
+
+        if not (top_left.row() <= source_index.row() <= bottom_right.row()):
+            return
+
+        source_model = self._publish_proxy_model.sourceModel()
+        item = source_model.itemFromIndex(source_index)
+        if item is None:
+            return
+
+        # Update the top-right details_image from the item's icon
+        icon = item.icon()
+        if not icon.isNull():
+            pixmap = icon.pixmap(512)
+            if not pixmap.isNull():
+                target_size = self.ui.details_image.size()
+                scaled = pixmap.scaled(
+                    target_size,
+                    QtCore.Qt.KeepAspectRatio,
+                    QtCore.Qt.SmoothTransformation,
+                )
+                self.ui.details_image.setPixmap(scaled)
+                self.ui.details_image.setScaledContents(False)
+
+    def _update_actions_for_variant(
+        self,
+        asset_id: str,
+        variant_sg_dicts: dict,
+    ) -> None:
+        """Rebuild the details-panel action menu and history for the selected variant cell.
+
+        Called both when the details panel first renders a variant container
+        (to seed the default option) and whenever the user changes a variant
+        selection in :class:`~flowam.variant_selector_widget.VariantSelectorWidget`.
+
+        :param asset_id: Asset id of the selected variant cell.
+        :param variant_sg_dicts: Pre-built sg_data dicts keyed by asset_id.
+        """
+        sg_dict = variant_sg_dicts.get(asset_id)
+        if not sg_dict:
+            self.ui.detail_actions_btn.setVisible(False)
+            return
+
+        # Actions menu
+        actions = self._action_manager.get_actions_for_publish(
+            sg_dict, self._action_manager.UI_AREA_DETAILS
+        )
+        self._details_action_menu.clear()
+        if actions:
+            for a in actions:
+                self._dynamic_widgets.append(a)
+                self._details_action_menu.addAction(a)
+            self.ui.detail_actions_btn.setVisible(True)
+        else:
+            self.ui.detail_actions_btn.setVisible(False)
+
+        # Version history for the selected variant cell
+        if self._medm_history_model is not None and (
+            sg_dict.get("_medm_asset") is not None
+            or sg_dict.get("_medm_draft") is not None
+        ):
+            self._publish_history_proxy.setSourceModel(self._medm_history_model)
+            self._medm_history_model.load_data(sg_dict)
+        else:
+            self._publish_history_proxy.setSourceModel(self._publish_history_model)
+            self._publish_history_model.load_data(sg_dict)
+        self._update_history_view_height()
 
     def _on_detail_version_playback(self):
         """
@@ -2499,6 +2698,9 @@ class AppDialog(QtGui.QWidget):
             self._medm_cache,
             self._medm_thumbnail_service,
         )
+
+        # Re-apply the center-panel details thumbnail when it arrives async.
+        self._medm_publish_model.dataChanged.connect(self._on_publish_item_data_changed)
 
         self._medm_tree_view.selectionModel().selectionChanged.connect(
             self._on_medm_tree_selection_changed

--- a/python/tk_multi_loader/dialog.py
+++ b/python/tk_multi_loader/dialog.py
@@ -1146,8 +1146,8 @@ class AppDialog(QtGui.QWidget):
                 # the actions menu through the currently selected variant.
                 # ----------------------------------------------------------
                 variant_sets = sg_item.get("_variant_sets") if sg_item else None
-                variant_sg_dicts = (
-                    sg_item.get("_variant_sg_dicts", {}) if sg_item else {}
+                variant_data_dicts = (
+                    sg_item.get("_variant_data_dicts", {}) if sg_item else {}
                 )
 
                 # Tear down any previous variant selector.
@@ -1168,7 +1168,7 @@ class AppDialog(QtGui.QWidget):
                     # When the user picks a different variant, refresh the
                     # actions menu for that variant.
                     selector.selection_changed.connect(
-                        lambda _set_name, _variant_name, asset_id, variant_set_dicts=variant_sg_dicts: (
+                        lambda _set_name, _variant_name, asset_id, variant_set_dicts=variant_data_dicts: (
                             self._update_actions_for_variant(
                                 asset_id, variant_set_dicts
                             )
@@ -1181,13 +1181,13 @@ class AppDialog(QtGui.QWidget):
                         self._medm_history_model.clear()
                     self._update_history_view_height()
 
-                    # Seed the actions menu and history with the first option of
-                    # the first set so the panel is immediately usable.
-                    first_set_variants = next(iter(variant_sets.values()), [])
-                    if first_set_variants:
-                        _first_asset_id = first_set_variants[0][1]
+                    # Seed the actions menu and history with the widget's current
+                    # (default) selection so the panel is immediately usable.
+                    first_set_name = next(iter(variant_sets))
+                    default_asset_id = selector.get_selected_asset_id(first_set_name)
+                    if default_asset_id:
                         self._update_actions_for_variant(
-                            _first_asset_id, variant_sg_dicts
+                            default_asset_id, variant_data_dicts
                         )
                 else:
                     # Normal (non-variant) publish: restore history view and
@@ -1366,7 +1366,7 @@ class AppDialog(QtGui.QWidget):
     def _update_actions_for_variant(
         self,
         asset_id: str,
-        variant_sg_dicts: dict,
+        variant_data_dicts: dict,
     ) -> None:
         """Rebuild the details-panel action menu and history for the selected variant cell.
 
@@ -1375,9 +1375,9 @@ class AppDialog(QtGui.QWidget):
         selection in :class:`~flowam.variant_selector_widget.VariantSelectorWidget`.
 
         :param asset_id: Asset id of the selected variant cell.
-        :param variant_sg_dicts: Pre-built sg_data dicts keyed by asset_id.
+        :param variant_data_dicts: Pre-built sg_data dicts keyed by asset_id.
         """
-        sg_dict = variant_sg_dicts.get(asset_id)
+        sg_dict = variant_data_dicts.get(asset_id)
         if not sg_dict:
             self.ui.detail_actions_btn.setVisible(False)
             return

--- a/python/tk_multi_loader/flowam/__init__.py
+++ b/python/tk_multi_loader/flowam/__init__.py
@@ -33,6 +33,7 @@ try:
         get_templates,
     )
     from .thumbnail_service import MedmThumbnailService
+    from .variant_selector_widget import VariantSelectorWidget
 except ImportError as exc:
     logger.error(
         "tk-multi-loader2: There was an error importing the 'flowam' module.\n"

--- a/python/tk_multi_loader/flowam/latestpublish_model.py
+++ b/python/tk_multi_loader/flowam/latestpublish_model.py
@@ -61,6 +61,9 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
         QtCore.Qt.UserRole + 202
     )  # Stores DraftInfo for draft rows (shared with history model)
 
+    # Stores {set_name: [(variant_name, asset_id)]} for variant container cards.
+    VARIANT_SETS_ROLE = QtCore.Qt.UserRole + 203
+
     # Signals
     loadingStarted = QtCore.Signal()
     loadingFinished = QtCore.Signal()
@@ -197,6 +200,33 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
 
         self._app.log_debug(f"FlowAM: Asset extracted: {asset.name}")
 
+        # ------------------------------------------------------------------
+        # Variant container check.
+        # If the selected asset owns component.variantSet components it is a
+        # logical container grouping alternative representations (e.g. maya /
+        # alembic).  In that case we show the container itself as a single
+        # center-panel card and store variant metadata on it; the variant cell
+        # child assets are NOT shown as separate cards.
+        # ------------------------------------------------------------------
+        try:
+            variant_sets = asset.get_variant_sets()
+        except Exception as _e:
+            # Schema not registered on this hub or network error – treat as
+            # a plain (non-variant) asset.
+            self._app.log_debug(
+                f"FlowAM: Could not read variant sets for '{asset.name}': {_e}"
+            )
+            variant_sets = {}
+
+        if variant_sets:
+            self._app.log_debug(
+                f"FlowAM: '{asset.name}' is a variant container "
+                f"({list(variant_sets.keys())})"
+            )
+            self._populate_variant_container(asset, variant_sets)
+            # Publish-type count is updated inside the helper above.
+            return
+
         children_asset_sg_dicts = self._fetch_asset_children(asset)
 
         # If the selected asset has no (non-structural) children it may itself
@@ -293,6 +323,79 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
             f"FlowAM: center panel now has {self.rowCount()} items "
             f"({draft_count} draft(s), {published_count} published)"
         )
+
+        sg_publish_type_counts = self._calculate_sg_publish_type_counts()
+        self._publish_type_model.set_active_types(sg_publish_type_counts)
+
+    def _populate_variant_container(
+        self,
+        asset: objects.FlowAsset,
+        variant_sets: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        """Show *asset* as a single center-panel card for a variant container.
+
+        The card carries two extra keys in its sg_data:
+
+        * ``_variant_sets``: the raw variant-sets dict
+          ``{set_name: [(variant_name, asset_id)]}``
+        * ``_variant_sg_dicts``: pre-built sg_data dicts keyed by *asset_id*,
+          one per variant cell.  These are used by the details panel to
+          populate the actions menu when the user picks a variant.
+
+        :param asset: The container :class:`FlowAsset`.
+        :param variant_sets: Mapping returned by :meth:`ComponentMixin.get_variant_sets`.
+        """
+        # Collect every unique variant-cell asset_id across all sets.
+        all_variant_asset_ids: set[str] = set()
+        for variants in variant_sets.values():
+            for _vname, asset_id in variants:
+                if asset_id:
+                    all_variant_asset_ids.add(asset_id)
+
+        # Fetch the variant cell FlowAsset objects (best-effort; use cache).
+        variant_sg_dicts: dict[str, dict[str, Any]] = {}
+        try:
+            if asset.id in self._cache.children:
+                child_assets = self._cache.children[asset.id]
+            else:
+                child_assets = list(asset.iterate_children())
+                self._cache.children[asset.id] = child_assets
+
+            for child in child_assets:
+                if child.id in all_variant_asset_ids:
+                    try:
+                        variant_sg_dicts[child.id] = self._asset_to_sg_dict(child)
+                    except Exception as _e:
+                        self._app.log_debug(
+                            f"FlowAM: Could not build sg_dict for variant cell "
+                            f"'{child.name}': {_e}"
+                        )
+        except Exception as _e:
+            self._app.log_warning(
+                f"FlowAM: Could not fetch variant cell children for "
+                f"'{asset.name}': {_e}"
+            )
+
+        # Build the container card.
+        sg_dict = self._asset_to_sg_dict(asset)
+        sg_dict["_variant_sets"] = variant_sets
+        sg_dict["_variant_sg_dicts"] = variant_sg_dicts
+
+        # Use the first variant cell child's revision as the container thumbnail.
+        # Going through child_assets directly avoids any risk of the asset ID
+        # format in variant component properties not matching child.id exactly.
+        first_variant_child = next(
+            (child for child in child_assets if child.id in all_variant_asset_ids),
+            None,
+        )
+        # Fallback: if the ID lookup found nothing (format mismatch), take the
+        # first child regardless so SOME thumbnail is shown.
+        if first_variant_child is None and child_assets:
+            first_variant_child = child_assets[0]
+        if first_variant_child:
+            sg_dict["_thumbnail_revision_id"] = first_variant_child.revision_id
+
+        self._add_sg_dict_as_qt_item(sg_dict)
 
         sg_publish_type_counts = self._calculate_sg_publish_type_counts()
         self._publish_type_model.set_active_types(sg_publish_type_counts)

--- a/python/tk_multi_loader/flowam/latestpublish_model.py
+++ b/python/tk_multi_loader/flowam/latestpublish_model.py
@@ -334,13 +334,14 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
     ) -> None:
         """Show *asset* as a single center-panel card for a variant container.
 
-        The card carries two extra keys in its sg_data:
+        Builds the container's sg_data dict and attaches two extra keys:
 
         * ``_variant_sets``: the raw variant-sets dict
-          ``{set_name: [(variant_name, asset_id)]}``
-        * ``_variant_sg_dicts``: pre-built sg_data dicts keyed by *asset_id*,
-          one per variant cell.  These are used by the details panel to
-          populate the actions menu when the user picks a variant.
+          ``{set_name: [(variant_name, asset_id)]}`` read from the asset's
+          ``component.variantSet`` components.
+        * ``_variant_sg_dicts``: sg_data dicts built here for each variant cell,
+          keyed by *asset_id*.  The details panel uses these to populate the
+          actions menu when the user picks a variant from the selector.
 
         :param asset: The container :class:`FlowAsset`.
         :param variant_sets: Mapping returned by :meth:`ComponentMixin.get_variant_sets`.
@@ -348,18 +349,14 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
         # Collect every unique variant-cell asset_id across all sets.
         all_variant_asset_ids: set[str] = set()
         for variants in variant_sets.values():
-            for _vname, asset_id in variants:
-                if asset_id:
-                    all_variant_asset_ids.add(asset_id)
+            for _variant_set_name, variant_set_asset_id in variants:
+                if variant_set_asset_id:
+                    all_variant_asset_ids.add(variant_set_asset_id)
 
         # Fetch the variant cell FlowAsset objects (best-effort; use cache).
         variant_sg_dicts: dict[str, dict[str, Any]] = {}
         try:
-            if asset.id in self._cache.children:
-                child_assets = self._cache.children[asset.id]
-            else:
-                child_assets = list(asset.iterate_children())
-                self._cache.children[asset.id] = child_assets
+            child_assets = self._get_cached_children(asset)
 
             for child in child_assets:
                 if child.id in all_variant_asset_ids:
@@ -435,11 +432,7 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
         children_asset_sg_dicts = []
 
         try:
-            if asset.id in self._cache.children:
-                child_assets = self._cache.children[asset.id]
-            else:
-                child_assets = list(asset.iterate_children())
-                self._cache.children[asset.id] = child_assets
+            child_assets = self._get_cached_children(asset)
 
             for child_asset in child_assets:
                 if _is_structural_asset_util(child_asset):
@@ -639,6 +632,20 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
 
     def _resolve_publish_type(self, medm_type_id_str: str) -> tuple:
         return resolve_publish_type(medm_type_id_str, self._cache, self._app)
+
+    def _get_cached_children(self, asset: objects.FlowAsset) -> list[objects.FlowAsset]:
+        """Return the direct children of *asset*, using the shared cache.
+
+        Populates :attr:`MedmSharedCache.children` on the first call so that
+        subsequent requests (e.g. from :class:`MedmEntityModel`) never issue a
+        duplicate API round-trip.
+
+        :param asset: The :class:`FlowAsset` whose children are needed.
+        :returns: List of direct child :class:`FlowAsset` objects.
+        """
+        if asset.id not in self._cache.children:
+            self._cache.children[asset.id] = list(asset.iterate_children())
+        return self._cache.children[asset.id]
 
     def _add_sg_dict_as_qt_item(self, sg_item: dict[str, Any]) -> None:
         """

--- a/python/tk_multi_loader/flowam/latestpublish_model.py
+++ b/python/tk_multi_loader/flowam/latestpublish_model.py
@@ -339,7 +339,7 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
         * ``_variant_sets``: the raw variant-sets dict
           ``{set_name: [(variant_name, asset_id)]}`` read from the asset's
           ``component.variantSet`` components.
-        * ``_variant_sg_dicts``: sg_data dicts built here for each variant cell,
+        * ``_variant_data_dicts``: sg_data dicts built here for each variant cell,
           keyed by *asset_id*.  The details panel uses these to populate the
           actions menu when the user picks a variant from the selector.
 
@@ -354,14 +354,14 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
                     all_variant_asset_ids.add(variant_set_asset_id)
 
         # Fetch the variant cell FlowAsset objects (best-effort; use cache).
-        variant_sg_dicts: dict[str, dict[str, Any]] = {}
+        variant_data_dicts: dict[str, dict[str, Any]] = {}
         try:
             child_assets = self._get_cached_children(asset)
 
             for child in child_assets:
                 if child.id in all_variant_asset_ids:
                     try:
-                        variant_sg_dicts[child.id] = self._asset_to_sg_dict(child)
+                        variant_data_dicts[child.id] = self._asset_to_sg_dict(child)
                     except Exception as _e:
                         self._app.log_debug(
                             f"FlowAM: Could not build sg_dict for variant cell "
@@ -376,7 +376,7 @@ class MedmLatestPublishModel(QtGui.QStandardItemModel):
         # Build the container card.
         sg_dict = self._asset_to_sg_dict(asset)
         sg_dict["_variant_sets"] = variant_sets
-        sg_dict["_variant_sg_dicts"] = variant_sg_dicts
+        sg_dict["_variant_data_dicts"] = variant_data_dicts
 
         # Use the first variant cell child's revision as the container thumbnail.
         # Going through child_assets directly avoids any risk of the asset ID

--- a/python/tk_multi_loader/flowam/variant_selector_widget.py
+++ b/python/tk_multi_loader/flowam/variant_selector_widget.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Software Inc. License Agreement included in this
+# distribution package. See LICENSE.
+
+"""Variant selector widget for FlowAM variant container assets.
+
+Displayed in the details panel when a container asset carrying
+``component.variantSet`` components is selected in the center panel.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import sgtk
+from sgtk.platform.qt import QtCore, QtGui
+
+logger = sgtk.platform.get_logger(__name__)
+
+
+class VariantSelectorWidget(QtGui.QWidget):
+    """Widget that renders one labelled row per variant set axis.
+
+    Each row shows the set name as a label and a :class:`QComboBox` listing
+    the available variant options.  Selecting a different option emits
+    :attr:`selection_changed`.
+
+    :param variant_sets: Mapping of ``set_name -> [(variant_name, asset_id)]``.
+        Preserves the insertion order returned by
+        :meth:`~ComponentMixin.get_variant_sets`.
+    :param parent: Parent :class:`QWidget`.
+    """
+
+    # Emitted whenever the user changes a variant selection.
+    # Arguments: set_name (str), variant_name (str), asset_id (str)
+    selection_changed = QtCore.Signal(str, str, str)
+
+    def __init__(
+        self,
+        variant_sets: Dict[str, List[Tuple[str, str]]],
+        parent: Optional[QtGui.QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        # set_name -> [(variant_name, asset_id), ...]
+        self._variant_sets = variant_sets
+        # set_name -> QComboBox
+        self._combos: Dict[str, QtGui.QComboBox] = {}
+
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def get_selected_asset_id(self, set_name: str) -> Optional[str]:
+        """Return the currently selected asset_id for *set_name*, or ``None``."""
+        combo = self._combos.get(set_name)
+        return combo.currentData() if combo else None
+
+    def get_all_selections(self) -> Dict[str, Tuple[str, str]]:
+        """Return ``{set_name: (variant_name, asset_id)}`` for every set."""
+        return {
+            sn: (cb.currentText(), cb.currentData()) for sn, cb in self._combos.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Private – UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        outer = QtGui.QVBoxLayout(self)
+        outer.setContentsMargins(0, 4, 0, 0)
+        outer.setSpacing(6)
+
+        # Thin separator line to visually separate from the metadata table above
+        line = QtGui.QFrame(self)
+        line.setFrameShape(QtGui.QFrame.HLine)
+        line.setFrameShadow(QtGui.QFrame.Sunken)
+        outer.addWidget(line)
+
+        label_style = "color: rgba(245, 245, 245, 178);"
+
+        for set_name, variants in self._variant_sets.items():
+            row = QtGui.QHBoxLayout()
+            row.setSpacing(8)
+
+            # Capitalise first letter for a cleaner label
+            display_name = set_name[0].upper() + set_name[1:] if set_name else set_name
+            lbl = QtGui.QLabel(f"{display_name}:", self)
+            lbl.setStyleSheet(label_style)
+            lbl.setMinimumWidth(80)
+            row.addWidget(lbl)
+
+            combo = QtGui.QComboBox(self)
+            for variant_name, asset_id in variants:
+                combo.addItem(variant_name, userData=asset_id)
+
+            # Use a closure to capture the correct set_name per row
+            combo.currentIndexChanged.connect(
+                lambda _idx, sn=set_name, cb=combo: self._on_combo_changed(sn, cb)
+            )
+
+            self._combos[set_name] = combo
+            row.addWidget(combo, 1)
+            outer.addLayout(row)
+
+    def _on_combo_changed(self, set_name: str, combo: QtGui.QComboBox) -> None:
+        variant_name = combo.currentText()
+        asset_id = combo.currentData()
+        if asset_id:
+            self.selection_changed.emit(set_name, variant_name, asset_id)

--- a/python/tk_multi_loader/flowam/variant_selector_widget.py
+++ b/python/tk_multi_loader/flowam/variant_selector_widget.py
@@ -8,12 +8,6 @@
 # agreement to the Shotgun Software Inc. License Agreement included in this
 # distribution package. See LICENSE.
 
-"""Variant selector widget for FlowAM variant container assets.
-
-Displayed in the details panel when a container asset carrying
-``component.variantSet`` components is selected in the center panel.
-"""
-
 from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
@@ -30,11 +24,6 @@ class VariantSelectorWidget(QtGui.QWidget):
     Each row shows the set name as a label and a :class:`QComboBox` listing
     the available variant options.  Selecting a different option emits
     :attr:`selection_changed`.
-
-    :param variant_sets: Mapping of ``set_name -> [(variant_name, asset_id)]``.
-        Preserves the insertion order returned by
-        :meth:`~ComponentMixin.get_variant_sets`.
-    :param parent: Parent :class:`QWidget`.
     """
 
     # Emitted whenever the user changes a variant selection.
@@ -46,6 +35,12 @@ class VariantSelectorWidget(QtGui.QWidget):
         variant_sets: Dict[str, List[Tuple[str, str]]],
         parent: Optional[QtGui.QWidget] = None,
     ) -> None:
+        """
+        :param variant_sets: Mapping of ``set_name -> [(variant_name, asset_id)]``.
+            Preserves the insertion order returned by
+            :meth:`~ComponentMixin.get_variant_sets`.
+        :param parent: Parent :class:`QWidget`.
+        """
         super().__init__(parent)
 
         # set_name -> [(variant_name, asset_id), ...]
@@ -60,14 +55,23 @@ class VariantSelectorWidget(QtGui.QWidget):
     # ------------------------------------------------------------------
 
     def get_selected_asset_id(self, set_name: str) -> Optional[str]:
-        """Return the currently selected asset_id for *set_name*, or ``None``."""
+        """Return the currently selected asset_id for the given set.
+
+        :param set_name: The variant set name to query.
+        :returns: The ``asset_id`` of the currently selected option, or
+            ``None`` if *set_name* is not present.
+        """
         combo = self._combos.get(set_name)
         return combo.currentData() if combo else None
 
     def get_all_selections(self) -> Dict[str, Tuple[str, str]]:
-        """Return ``{set_name: (variant_name, asset_id)}`` for every set."""
+        """Return the current selection for every variant set.
+
+        :returns: Mapping of ``{set_name: (variant_name, asset_id)}``.
+        """
         return {
-            sn: (cb.currentText(), cb.currentData()) for sn, cb in self._combos.items()
+            set_name: (combo.currentText(), combo.currentData())
+            for set_name, combo in self._combos.items()
         }
 
     # ------------------------------------------------------------------
@@ -104,7 +108,9 @@ class VariantSelectorWidget(QtGui.QWidget):
 
             # Use a closure to capture the correct set_name per row
             combo.currentIndexChanged.connect(
-                lambda _idx, sn=set_name, cb=combo: self._on_combo_changed(sn, cb)
+                lambda _idx, set_name=set_name, combo=combo: self._on_combo_changed(
+                    set_name, combo
+                )
             )
 
             self._combos[set_name] = combo

--- a/python/tk_multi_loader/model_hierarchy.py
+++ b/python/tk_multi_loader/model_hierarchy.py
@@ -109,6 +109,7 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
             entity_fields = {"__all__": default_fields}
 
         # Load a hierarchy that leads to entities linked via "PublishedFile.entity".
+        self._root_entity = root_entity
         self.load_data(
             "PublishedFile.entity", root=root_entity, entity_fields=entity_fields
         )
@@ -121,6 +122,6 @@ class SgHierarchyModel(SimpleShotgunHierarchyModel):
 
         self.load_data(
             self._seed_entity_field,
-            entity=self._root_entity,
+            root=self._root_entity,
             entity_fields=self._entity_fields,
         )

--- a/python/tk_multi_loader/proxymodel_latestpublish.py
+++ b/python/tk_multi_loader/proxymodel_latestpublish.py
@@ -77,27 +77,26 @@ class SgLatestPublishProxyModel(FilterItemProxyModel):
         if not base_model_accepts:
             return False
 
-        if self._valid_type_ids is None:
-            # accept all!
-            return True
-
         model = self.sourceModel()
 
         current_item = model.invisibleRootItem().child(
             source_row
         )  # assume non-tree structure
 
-        # first analyze any search filtering
+        # Apply search filtering first, regardless of type filter state.
         if self._search_filter:
-
-            # there is a search filter entered
             field_data = shotgun_model.get_sanitized_data(
                 current_item, SgLatestPublishModel.SEARCHABLE_NAME
             )
-
+            if not field_data:
+                return False
             if self._search_filter.lower() not in field_data.lower():
                 # item text is not matching search filter
                 return False
+
+        if self._valid_type_ids is None:
+            # No type filter active - accept all items.
+            return True
 
         # now check if folders should be shown
         is_folder = current_item.data(SgLatestPublishModel.IS_FOLDER_ROLE)


### PR DESCRIPTION
## Description
This pull request adds comprehensive support for FlowAM variant container assets in the loader dialog, enabling users to select and interact with different asset variants directly from the UI. The main changes introduce a new variant selector widget, update the data models and dialog logic to recognize and handle variant containers, and ensure that the UI updates correctly when variant selections or async thumbnail loads occur.

**FlowAM Variant Container Support**

* Added a new `VariantSelectorWidget` (`flowam/variant_selector_widget.py`) that appears in the details panel when a FlowAM variant container asset is selected. This widget allows users to select among available variants, emitting signals to update the actions menu and history accordingly. [[1]](diffhunk://#diff-e237095509fe7126684765c4d51382734dd96c17bab2b66b751e06a09b65e7eeR1-R118) [[2]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031L1133-R1193)
* Updated the loader dialog (`dialog.py`) to detect when a selected asset is a variant container, display the variant selector, and route actions/history through the currently selected variant. The dialog also seeds the UI with the first variant by default. [[1]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031L1133-R1193) [[2]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031R1255-R1265)

**Model and Data Handling Enhancements**

* Modified `MedmLatestPublishModel` (`latestpublish_model.py`) to identify variant containers, store variant sets and prebuilt sg_data for each variant, and provide a helper to populate the model with a single card for the container asset. [[1]](diffhunk://#diff-1ed57a88e0d5321a3af194170169df8806da64d93205c065f8f50e4d9bc7d7b6R203-R229) [[2]](diffhunk://#diff-1ed57a88e0d5321a3af194170169df8806da64d93205c065f8f50e4d9bc7d7b6R330-R402)
* Added a new role (`VARIANT_SETS_ROLE`) to the model for storing variant set metadata.

**UI and Async Thumbnail Handling**

* Ensured that when a thumbnail for a history or publish item arrives asynchronously, the details panel updates the image if that item is currently selected. This includes new signal connections and handlers for both history and publish models. [[1]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031R186-R191) [[2]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031R2702-R2704) [[3]](diffhunk://#diff-6ce7f50bc61858ca8f8bfd954cfe0d1280521c84dbc2f170ff01da4399d3f031R1276-R1407)

**Imports and Initialization**

* Updated imports to include the new `VariantSelectorWidget` in the FlowAM module initialization.
* Added initialization and cleanup logic for the variant selector widget in the dialog.

## Screenshots

<img width="1194" height="683" alt="image" src="https://github.com/user-attachments/assets/3fa86269-c0fa-4e0c-911c-c0ed98179fef" />

<img width="1766" height="540" alt="image" src="https://github.com/user-attachments/assets/25786756-d961-473c-9d89-ab7b059f25f4" />
