### PR TITLE
SG-44523 Fix build new scene on Nuke

### DIFF
--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -336,7 +336,7 @@ class NukeActions(HookBaseClass):
         if app.flowam_available:
             return {
                 "Project": ["build_new_template"],
-                "Task": ["build_new_scene"],
+                "Task": ["build_new_script"],
             }
 
         return {}


### PR DESCRIPTION
This pull request makes a small update to the `entity_mappings` method in `hooks/tk-nuke_actions.py`. The action mapped to the `Task` entity has been changed from `build_new_scene` to `build_new_script`.