### PR TITLE
SG-44526 Fetch dependencies when accessing references and templates

### DIFF
--- a/python/tk_multi_loader/flowam/create.py
+++ b/python/tk_multi_loader/flowam/create.py
@@ -181,7 +181,7 @@ def get_template_source_path(template: objects.FlowAsset) -> str:
         Full path to template file in blob storage.
     """
     revision = template.get_latest_revision()
-    revision.fetch(component_purpose=globals.SOURCE_PURPOSE)
+    revision.fetch(component_purpose=globals.SOURCE_PURPOSE, fetch_dependencies=True)
     return revision.get_storage_component_path(component_purpose=globals.SOURCE_PURPOSE)
 
 

--- a/python/tk_multi_loader/flowam/reference.py
+++ b/python/tk_multi_loader/flowam/reference.py
@@ -62,7 +62,7 @@ def reference_revision(revision_id: str) -> str:
         raise CreateReferenceError(input_id=revision_id, details=msg) from exc
 
     # Fetch source component of revision
-    revision.fetch(component_purpose=globals.SOURCE_PURPOSE)
+    revision.fetch(component_purpose=globals.SOURCE_PURPOSE, fetch_dependencies=True)
 
     # Get path to source path of revision in local storage
     file_path = revision.get_storage_component_path(
@@ -121,7 +121,7 @@ def copy_reference_link(revision_id: str) -> str:
         raise CreateReferenceError(input_id=revision_id, details=msg) from exc
 
     # Fetch source component of revision
-    revision.fetch(component_purpose=globals.SOURCE_PURPOSE)
+    revision.fetch(component_purpose=globals.SOURCE_PURPOSE, fetch_dependencies=True)
 
     # Get path to source path of revision in local storage
     file_path = revision.get_storage_component_path(


### PR DESCRIPTION
Fixing migration bug where dependencies were not being fetched along with a revision.
Introduced because in the migration of the fetch function, a new fetch_dependencies parameter was introduced and set to False by default. The original code did always fetched dependencies. Migrated callers of fetch function did not explicitly set this parameter to True.