### PR TITLE
SG-44680 Prevent downloading and copy ref link for container assets

### DIFF
--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -82,9 +82,7 @@ class DesktopActions(HookBaseClass):
             if (
                 "download" in actions
                 and sg_publish_data.get("type") == "PublishedFile"
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 version_number = sg_publish_data.get("version_number")
 
@@ -132,9 +130,7 @@ class DesktopActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 > flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -79,7 +79,13 @@ class DesktopActions(HookBaseClass):
         if app.flowam_available:
             flowam_actions = app.flowam.FlowAMActions()
 
-            if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
+            if (
+                "download" in actions
+                and sg_publish_data.get("type") == "PublishedFile"
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
+            ):
                 version_number = sg_publish_data.get("version_number")
 
                 if (
@@ -126,6 +132,9 @@ class DesktopActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 > flowam_actions.DRAFT_VERSION_IDENTIFIER
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-desktop_actions.py
+++ b/hooks/tk-desktop_actions.py
@@ -82,7 +82,7 @@ class DesktopActions(HookBaseClass):
             if (
                 "download" in actions
                 and sg_publish_data.get("type") == "PublishedFile"
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):
@@ -132,7 +132,7 @@ class DesktopActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 > flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -129,9 +129,7 @@ class HoudiniActions(HookBaseClass):
             if (
                 "download" in actions
                 and sg_publish_data.get("type") == "PublishedFile"
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 version_number = sg_publish_data.get("version_number")
 
@@ -169,9 +167,7 @@ class HoudiniActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -129,7 +129,7 @@ class HoudiniActions(HookBaseClass):
             if (
                 "download" in actions
                 and sg_publish_data.get("type") == "PublishedFile"
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):
@@ -169,7 +169,7 @@ class HoudiniActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):

--- a/hooks/tk-houdini_actions.py
+++ b/hooks/tk-houdini_actions.py
@@ -126,7 +126,13 @@ class HoudiniActions(HookBaseClass):
                         }
                     )
 
-            if "download" in actions and sg_publish_data.get("type") == "PublishedFile":
+            if (
+                "download" in actions
+                and sg_publish_data.get("type") == "PublishedFile"
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
+            ):
                 version_number = sg_publish_data.get("version_number")
 
                 if (
@@ -163,6 +169,9 @@ class HoudiniActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -164,9 +164,7 @@ class MayaActions(HookBaseClass):
                     and sg_publish_data.get("version_number")
                     != flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {
@@ -214,9 +212,7 @@ class MayaActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -164,6 +164,7 @@ class MayaActions(HookBaseClass):
                     and sg_publish_data.get("version_number")
                     != flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
+                and not flowam_actions.is_container_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {
@@ -211,6 +212,7 @@ class MayaActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
+                and not flowam_actions.is_container_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {
@@ -316,6 +318,7 @@ class MayaActions(HookBaseClass):
                 flowam_actions._build_new_template(sg_publish_data)
 
             if name == "download":
+                print("@@@@@", sg_publish_data.get("_medm_asset"))
                 flowam_actions._download_asset_revision(sg_publish_data)
 
             return

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -322,7 +322,6 @@ class MayaActions(HookBaseClass):
                 flowam_actions._build_new_template(sg_publish_data)
 
             if name == "download":
-                print("@@@@@", sg_publish_data.get("_medm_asset"))
                 flowam_actions._download_asset_revision(sg_publish_data)
 
             return

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -164,7 +164,7 @@ class MayaActions(HookBaseClass):
                     and sg_publish_data.get("version_number")
                     != flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):
@@ -214,7 +214,7 @@ class MayaActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):

--- a/hooks/tk-maya_actions.py
+++ b/hooks/tk-maya_actions.py
@@ -164,7 +164,9 @@ class MayaActions(HookBaseClass):
                     and sg_publish_data.get("version_number")
                     != flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
-                and not flowam_actions.is_container_asset(sg_publish_data.get("_medm_asset"))
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
             ):
                 action_instances.append(
                     {
@@ -212,7 +214,9 @@ class MayaActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_container_asset(sg_publish_data.get("_medm_asset"))
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -177,6 +177,9 @@ class NukeActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
+                and not flowam_actions.is_container_asset(
+                    sg_publish_data.get("_medm_asset")
+                )
             ):
                 action_instances.append(
                     {

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -177,7 +177,7 @@ class NukeActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_container_asset(
+                and not flowam_actions.is_root_asset(
                     sg_publish_data.get("_medm_asset")
                 )
             ):

--- a/hooks/tk-nuke_actions.py
+++ b/hooks/tk-nuke_actions.py
@@ -177,9 +177,7 @@ class NukeActions(HookBaseClass):
                     "version_number", flowam_actions.DRAFT_VERSION_IDENTIFIER
                 )
                 != flowam_actions.DRAFT_VERSION_IDENTIFIER
-                and not flowam_actions.is_root_asset(
-                    sg_publish_data.get("_medm_asset")
-                )
+                and not flowam_actions.is_root_asset(sg_publish_data.get("_medm_asset"))
             ):
                 action_instances.append(
                     {

--- a/python/tk_multi_loader/flowam/flowam_actions.py
+++ b/python/tk_multi_loader/flowam/flowam_actions.py
@@ -14,8 +14,8 @@ import functools
 import sgtk
 from sgtk import TankError
 from sgtk.platform.qt import QtGui
-from sgtk.flowam.create import CreateMode
-from tank_vendor.flow_integration_sdk import sandbox, exceptions
+from sgtk.flowam.create import CreateMode, CONTAINER_TYPE
+from tank_vendor.flow_integration_sdk import sandbox, exceptions, objects, schema
 
 from ..build_asset_dialog import BuildAssetDialog
 from ..build_template_dialog import BuildTemplateDialog
@@ -26,7 +26,12 @@ from .create import (
     create_dcc_workfile,
     create_template_workfile,
 )
-from .file import open_draft, download_revision, checkout_revision
+from .file import (
+    DownloadRevisionError,
+    open_draft,
+    download_revision,
+    checkout_revision,
+)
 from .reference import reference_revision, copy_reference_link
 
 
@@ -402,6 +407,21 @@ class FlowAMActions:
         engine = sgtk.platform.current_engine()
         return engine._get_dialog_parent()
 
+    def is_container_asset(self, asset: objects.FlowAsset) -> bool:
+        """
+        Determine if the given FlowAsset is a container asset.
+
+        :param asset: The FlowAsset to check.
+        :returns: True if the asset is a container, False otherwise.
+        """
+        if (
+            asset.find_component(type_id=schema.get_schema_id(CONTAINER_TYPE))
+            is not None
+        ):
+            return True
+
+        return False
+
     def _download_asset_revision(self, sg_publish_data: dict) -> None:
         """
         Download the given PublishedFile revision to the location specified.
@@ -416,7 +436,17 @@ class FlowAMActions:
             )
             raise TankError("No Revision ID found for this item {}.".format(item_id))
 
-        result = download_revision(flow_revision_id)
+        try:
+            result = download_revision(flow_revision_id)
+        except DownloadRevisionError as exc:
+            if 'Component of purpose "source" does not exist on revision.' in str(exc):
+                QtGui.QMessageBox.warning(
+                    None,
+                    "Warning",
+                    "This asset has no binaries to download.",
+                )
+                return
+            raise
 
         # Notify the user about the download result
         if result:

--- a/python/tk_multi_loader/flowam/flowam_actions.py
+++ b/python/tk_multi_loader/flowam/flowam_actions.py
@@ -13,9 +13,9 @@ import functools
 
 import sgtk
 from sgtk import TankError
+from sgtk.flowam.create import CONTAINER_TYPE, CreateMode
 from sgtk.platform.qt import QtGui
-from sgtk.flowam.create import CreateMode, CONTAINER_TYPE
-from tank_vendor.flow_integration_sdk import sandbox, exceptions, objects, schema
+from tank_vendor.flow_integration_sdk import exceptions, objects, sandbox, schema
 
 from ..build_asset_dialog import BuildAssetDialog
 from ..build_template_dialog import BuildTemplateDialog
@@ -28,11 +28,11 @@ from .create import (
 )
 from .file import (
     DownloadRevisionError,
-    open_draft,
-    download_revision,
     checkout_revision,
+    download_revision,
+    open_draft,
 )
-from .reference import reference_revision, copy_reference_link
+from .reference import copy_reference_link, reference_revision
 
 
 class FlowAMActions:

--- a/python/tk_multi_loader/flowam/flowam_actions.py
+++ b/python/tk_multi_loader/flowam/flowam_actions.py
@@ -407,20 +407,14 @@ class FlowAMActions:
         engine = sgtk.platform.current_engine()
         return engine._get_dialog_parent()
 
-    def is_container_asset(self, asset: objects.FlowAsset) -> bool:
+    def is_root_asset(self, asset: objects.FlowAsset) -> bool:
         """
-        Determine if the given FlowAsset is a container asset.
+        Determine if the given FlowAsset is a root asset.
 
         :param asset: The FlowAsset to check.
-        :returns: True if the asset is a container, False otherwise.
+        :returns: True if the asset is a root asset, False otherwise.
         """
-        if (
-            asset.find_component(type_id=schema.get_schema_id(CONTAINER_TYPE))
-            is not None
-        ):
-            return True
-
-        return False
+        return bool(asset.find_component(type_id=schema.get_schema_id(CONTAINER_TYPE)))
 
     def _download_asset_revision(self, sg_publish_data: dict) -> None:
         """


### PR DESCRIPTION
Base branch: #149 

Adds validation to prevent displaying "download" and "copy reference link" for asset containers (root assets) Introduced on the component.VariantSet data model.